### PR TITLE
Fix Mac launcher.

### DIFF
--- a/build/launcher/start_mac.command
+++ b/build/launcher/start_mac.command
@@ -1,1 +1,3 @@
+#!/bin/bash
+cd "$(dirname "$0")"
 java -jar j-wildfire-launcher.jar


### PR DESCRIPTION
Double-clicking a .command file runs it from the user's root (~) rather than the directory the .command file is in. To use this as intended, first `cd` to where the .command file is before trying to start the launcher.

See: http://stackoverflow.com/a/9660103
