### PR TITLE
A few fixes for running JWildfire on OSX

### DIFF
--- a/build/launcher/start_mac.command
+++ b/build/launcher/start_mac.command
@@ -1,1 +1,4 @@
-#!/bin/bashcd "$(dirname "$0")"java -Dapple.eawt.quitStrategy=CLOSE_ALL_WINDOWS -jar ./j-wildfire-launcher.jar
+#!/bin/bash
+cd "$(dirname "$0")"
+java -Dapple.eawt.quitStrategy=CLOSE_ALL_WINDOWS -jar ./j-wildfire-launcher.jar
+

--- a/build/launcher/start_mac.command
+++ b/build/launcher/start_mac.command
@@ -1,1 +1,1 @@
-#!/bin/bashcd "$(dirname "$0")"java -jar ./j-wildfire-launcher.jar
+#!/bin/bashcd "$(dirname "$0")"java -Dapple.eawt.quitStrategy=CLOSE_ALL_WINDOWS -jar ./j-wildfire-launcher.jar

--- a/src/org/jwildfire/launcher/JDKScanner.java
+++ b/src/org/jwildfire/launcher/JDKScanner.java
@@ -28,7 +28,8 @@ public class JDKScanner {
   public void scan() {
     jdks.clear();
     currentVersionIdx = -1;
-
+    String osname = System.getProperty("os.name");
+    if (osname.startsWith("Windows")) {
     try {
       {
         List<String> keys = readStringSubKeys(HKEY_LOCAL_MACHINE, "SOFTWARE\\Javasoft\\Java Runtime Environment");
@@ -65,6 +66,7 @@ public class JDKScanner {
       catch (Throwable ex) {
 
       }
+    }
     }
 
     if (jdks.size() == 0) {
@@ -135,6 +137,9 @@ public class JDKScanner {
   }
 
   static {
+      
+    String osname = System.getProperty("os.name");
+    if (osname.startsWith("Windows")) {
     try {
       regOpenKey = userClass.getDeclaredMethod("WindowsRegOpenKey", new Class[] { int.class, byte[].class, int.class });
       regOpenKey.setAccessible(true);
@@ -149,6 +154,7 @@ public class JDKScanner {
     }
     catch (Exception e) {
       e.printStackTrace();
+    }
     }
   }
 


### PR DESCRIPTION
Issues fixed:

1.Running JWildfire with start_mac.command doesn't work. I was experiencing same symptoms as herb37 reported on JWildfire forum: http://jwildfire.org/forum/viewtopic.php?f=5&t=1728&p=3807
Problem was fixed when removed/replaced odd newline/return chars in start_mac.command
2. Unreliable saving of prefs on OSX upon JWildfire exit - sometimes would work, sometimes not. Problem was that OSX handles program exit differently when using menubar Quit or keyboard shortcut command-Q. Solution is to set env variable in java executable call in start_mac.command that forces OSX to behave consistently.
3. Fixed NoSuchMethodException reporting on OSX launcher startup. Problem was Windows-specific method calls, fixed by checking os.name and only making those calls if running on Windows OS. I believe this also fixes similar issue reported under Linux by chronologicaldot on JWildfire forum: http://jwildfire.org/forum/viewtopic.php?f=6&t=1718
