### PR TITLE
Dynamic parameter expansion

### DIFF
--- a/src/org/jwildfire/create/tina/swing/TinaController.java
+++ b/src/org/jwildfire/create/tina/swing/TinaController.java
@@ -2991,6 +2991,12 @@ public class TinaController implements FlameHolder, LayerHolder, ScriptRunnerEnv
 
             double val = Tools.stringToDouble(valStr) + pDelta;
             var.getFunc().setParameter(selected, val);
+            if (var.getFunc().dynamicParameterExpansion(selected)) {
+              // if setting the parameter can change the total number of parameters, 
+              //    then refresh parameter UI (and reselect parameter that was changed)
+              this.refreshParamCmb(data.TinaNonlinearControlsRows[pIdx], xForm, var);
+              data.TinaNonlinearControlsRows[pIdx].getNonlinearParamsCmb().setSelectedItem(selected);
+            }
             data.TinaNonlinearControlsRows[pIdx].getNonlinearParamsREd().setText(Tools.doubleToString(val));
           }
           else if ((idx = var.getFunc().getRessourceIndex(selected)) >= 0) {
@@ -3130,7 +3136,7 @@ public class TinaController implements FlameHolder, LayerHolder, ScriptRunnerEnv
                     String valStr = dlg.getRessourceValue();
                     byte[] valByteArray = valStr != null ? valStr.getBytes() : null;
                     var.getFunc().setRessource(rName, valByteArray);
-                    if (var.getFunc().ressourceCanModifyParams()) {
+                    if (var.getFunc().ressourceCanModifyParams(rName)) {
                       // forcing refresh of params UI in case setting resource changes available params or param values
                       this.refreshParamCmb(data.TinaNonlinearControlsRows[pIdx], xForm, var);
                     }

--- a/src/org/jwildfire/create/tina/variation/CustomFullVariationWrapperFunc.java
+++ b/src/org/jwildfire/create/tina/variation/CustomFullVariationWrapperFunc.java
@@ -460,9 +460,23 @@ public class CustomFullVariationWrapperFunc extends VariationFunc {
     return varCopy;
   }
 
+  public boolean ressourceCanModifyParams(String resourceName) {
+    if (resourceName.equalsIgnoreCase(RESSOURCE_CODE)) { return true; }
+    else { return full_variation.ressourceCanModifyParams(resourceName); }
+  }
+  
   @Override
   public boolean ressourceCanModifyParams() {
     return true;
+  }
+    
+  @Override
+  public boolean dynamicParameterExpansion(String paramName) {
+    return full_variation.dynamicParameterExpansion(paramName);
+  }
+  
+  public boolean dynamicParameterExpansion() {
+    return full_variation.dynamicParameterExpansion();
   }
 
   @Override

--- a/src/org/jwildfire/create/tina/variation/VariationFunc.java
+++ b/src/org/jwildfire/create/tina/variation/VariationFunc.java
@@ -166,5 +166,16 @@ public abstract class VariationFunc implements Serializable {
   }
 
   public boolean ressourceCanModifyParams()  { return false; }
+  
+  /**
+   * if dynamicParameterExpansion is true, it means that variation function 
+   *   can dynamically add (or remove) parameters, depending on values of other parameters
+   *       in other words, calls to setParameter() 
+   *       can change what is returned by getParameterNames() and getParameterValues()
+   * current implementation to handle this assumes only one level depth of parameter expansion 
+   *       that is, if changed to parameter A can cause a parameter B to be dynamically added/removed
+   *       then changes to parameter B cannot in turn cause additional parameters to be added/removed
+   */
+  public boolean dynamicParameterExpansion() { return false; }
 
 }

--- a/src/org/jwildfire/create/tina/variation/VariationFunc.java
+++ b/src/org/jwildfire/create/tina/variation/VariationFunc.java
@@ -164,18 +164,30 @@ public abstract class VariationFunc implements Serializable {
     }
     return varCopy;
   }
-
-  public boolean ressourceCanModifyParams()  { return false; }
+  
+  /** 
+   * if resourceCanModifyParams is true, it means that variation function
+   *   can dynamically add (or remove) parameters, depending on values of resource resourceName
+   *  in other words, calls to setRessource(resourceName, ...)) 
+   *       can change what is returned by getParameterNames() and getParameterValues()
+   */
+  public boolean ressourceCanModifyParams(String resourceName) { return false; }
+  
+  /** should return true if at least one resource can trigger parameter addition/removal */
+  public boolean ressourceCanModifyParams()  { return false; }  
   
   /**
    * if dynamicParameterExpansion is true, it means that variation function 
-   *   can dynamically add (or remove) parameters, depending on values of other parameters
-   *       in other words, calls to setParameter() 
+   *   can dynamically add (or remove) parameters, depending on values of parameter paramName
+   *       in other words, calls to setParameter(paramName, ...)) 
    *       can change what is returned by getParameterNames() and getParameterValues()
    * current implementation to handle this assumes only one level depth of parameter expansion 
-   *       that is, if changed to parameter A can cause a parameter B to be dynamically added/removed
+   *       that is, if change to parameter paramName can cause a parameter B to be dynamically added/removed
    *       then changes to parameter B cannot in turn cause additional parameters to be added/removed
    */
+  public boolean dynamicParameterExpansion(String paramName) { return false; }
+  
+  /** should return true if at least one parameter can trigger parameter addition/removal */
   public boolean dynamicParameterExpansion() { return false; }
-
+  
 }


### PR DESCRIPTION
Adding support for dynamic parameter expansion for variation functions, so that changing value of one parameter cause adding or removing of additional parameters.  By default not used, but variations can add this capability by overriding boolean methods VariationFunc.dynamicParameterExpansion() and/or VariationFunc.dynamicParameterExpanstion(String paramName).