### PR TITLE
fixed previous commit that changed from Random nextDouble to nextInt

### DIFF
--- a/src/org/jwildfire/base/Tools.java
+++ b/src/org/jwildfire/base/Tools.java
@@ -597,11 +597,11 @@ public class Tools {
   /**
    * Returns a pseudorandom, uniformly distributed {@code int} value
    * between 0 (inclusive) and the specified value (exclusive).
-   * Uses {@link Random#nextInt(int)}
-   * @param bound the upper bound (exclusive). Must be positive.
-   * @return a random int value
+   * Uses {@link Random#nextInt(int)}.
+   * @param bound the upper bound (exclusive). Must be positive. (greater than zero)
+   * @return a random int value between 0 (inclusive) and bound (exclusive)
    */
   public static int randomInt(int bound) {
-    return (int) (RANDOM.nextDouble() * bound);
+    return RANDOM.nextInt(bound);
   }
 }

--- a/src/org/jwildfire/create/tina/variation/plot/WFFuncPresets.java
+++ b/src/org/jwildfire/create/tina/variation/plot/WFFuncPresets.java
@@ -128,6 +128,6 @@ public abstract class WFFuncPresets<T extends WFFuncPreset> {
   }
 
   public int getRandomPresetId() {
-    return minId + Tools.randomInt(maxId - minId);
+    return minId + (int) ((maxId - minId) * Math.random());
   }
 }


### PR DESCRIPTION
Reverted method `WFFuncPresets.getRandomPresetId()` to its original state.
All other callers of the new method `Tools.randomInt(int bound)` are using values that are greater than zero, so it makes sense to directly call `Random.nextInt(int bound)` there.