### PR TITLE
use Math.abs in MathLib.iabs and MathLib.fabs

### DIFF
--- a/src/org/jwildfire/base/mathlib/MathLib.java
+++ b/src/org/jwildfire/base/mathlib/MathLib.java
@@ -37,17 +37,11 @@ public final class MathLib {
   private static BaseMathLib baseLib = BaseMathLibType.FAST_MATH.createInstance();
 
   public static final int iabs(int var) {
-    if (var >= 0)
-      return var;
-    else
-      return 0 - var;
+    return Math.abs(var);
   }
 
   public static final double fabs(double var) {
-    if (var >= 0.0)
-      return var;
-    else
-      return 0.0 - var;
+    return Math.abs(var);
   }
 
   public static final int sign(double val) {


### PR DESCRIPTION
cleaner code and likely to run faster when Math.abs is implemented as
JVM intrinsic function.

closes #44