### PR TITLE
Fix misc. variation bugs

### DIFF
--- a/src/org/jwildfire/create/tina/variation/CircleCropFunc.java
+++ b/src/org/jwildfire/create/tina/variation/CircleCropFunc.java
@@ -57,8 +57,6 @@ public class CircleCropFunc extends VariationFunc {
     pAffineTP.x -= x0;
     pAffineTP.y -= y0;
 
-    pVarTP.z += vv * pAffineTP.z;
-
     double rad = sqrt(pAffineTP.x * pAffineTP.x + pAffineTP.y * pAffineTP.y);
     double ang = atan2(pAffineTP.y, pAffineTP.x);
     double rdc = cr + (pContext.random() * 0.5 * ca);

--- a/src/org/jwildfire/create/tina/variation/PostBWraps2Func.java
+++ b/src/org/jwildfire/create/tina/variation/PostBWraps2Func.java
@@ -63,8 +63,8 @@ public class PostBWraps2Func extends VariationFunc {
 
     if (fabs(cellsize) < SMALL_EPSILON) {
       // Linear if cells are too small
-      pVarTP.x += pAmount * Vx;
-      pVarTP.y += pAmount * Vy;
+      pVarTP.x = pAmount * Vx;
+      pVarTP.y = pAmount * Vy;
       return;
     }
 
@@ -76,8 +76,8 @@ public class PostBWraps2Func extends VariationFunc {
 
     if ((Lx * Lx + Ly * Ly) > _r2) {
       // Linear if outside the bubble
-      pVarTP.x += pAmount * Vx;
-      pVarTP.y += pAmount * Vy;
+      pVarTP.x = pAmount * Vx;
+      pVarTP.y = pAmount * Vy;
       return;
     }
 
@@ -101,8 +101,8 @@ public class PostBWraps2Func extends VariationFunc {
     Vy = Cy - s * Lx + c * Ly;
 
     // Finally add values in
-    pVarTP.x += pAmount * Vx;
-    pVarTP.y += pAmount * Vy;
+    pVarTP.x = pAmount * Vx;
+    pVarTP.y = pAmount * Vy;
   }
 
   @Override
@@ -141,7 +141,7 @@ public class PostBWraps2Func extends VariationFunc {
     double radius = 0.5 * (cellsize / (1.0 + space * space));
 
     // g2 is multiplier for radius
-    _g2 = gain * gain + 1.0e-6;
+    _g2 = gain * gain / cellsize + 1.0e-6;
 
     // Start max_bubble as maximum x or y value before applying bubble
     double max_bubble = _g2 * radius;

--- a/src/org/jwildfire/create/tina/variation/PostCircleCropFunc.java
+++ b/src/org/jwildfire/create/tina/variation/PostCircleCropFunc.java
@@ -57,8 +57,6 @@ public class PostCircleCropFunc extends VariationFunc {
     pVarTP.x -= x0;
     pVarTP.y -= y0;
 
-    pVarTP.z += vv * pVarTP.z;
-
     double rad = sqrt(pVarTP.x * pVarTP.x + pVarTP.y * pVarTP.y);
     double ang = atan2(pVarTP.y, pVarTP.x);
     double rdc = cr + (pContext.random() * 0.5 * ca);
@@ -75,16 +73,16 @@ public class PostCircleCropFunc extends VariationFunc {
       pVarTP.doHide = true;
     }
     else if (cr0 && !esc) {
-      pVarTP.x += vv * pVarTP.x + x0;
-      pVarTP.y += vv * pVarTP.y + y0;
+      pVarTP.x = vv * pVarTP.x + x0;
+      pVarTP.y = vv * pVarTP.y + y0;
     }
     else if (!cr0 && esc) {
-      pVarTP.x += vv * rdc * c + x0;
-      pVarTP.y += vv * rdc * s + y0;
+      pVarTP.x = vv * rdc * c + x0;
+      pVarTP.y = vv * rdc * s + y0;
     }
     else if (!cr0 && !esc) {
-      pVarTP.x += vv * pVarTP.x + x0;
-      pVarTP.y += vv * pVarTP.y + y0;
+      pVarTP.x = vv * pVarTP.x + x0;
+      pVarTP.y = vv * pVarTP.y + y0;
     }
   }
 

--- a/src/org/jwildfire/create/tina/variation/PostDCZTranslFunc.java
+++ b/src/org/jwildfire/create/tina/variation/PostDCZTranslFunc.java
@@ -48,13 +48,13 @@ public class PostDCZTranslFunc extends VariationFunc {
     double zf = factor * (pAffineTP.color - _x0) / _x1_m_x0;
     if (clamp != 0)
       zf = zf < 0 ? 0 : zf > 1 ? 1 : zf;
-    pVarTP.x += pAmount * pVarTP.x;
-    pVarTP.y += pAmount * pVarTP.y;
+    pVarTP.x = pAmount * pVarTP.x;
+    pVarTP.y = pAmount * pVarTP.y;
 
     if (overwrite == 0)
-      pVarTP.z += pAmount * pVarTP.z * zf;
+      pVarTP.z = pAmount * pVarTP.z * zf;
     else
-      pVarTP.z += pAmount * zf;
+      pVarTP.z = pAmount * zf;
   }
 
   @Override

--- a/src/org/jwildfire/create/tina/variation/PostHeatFunc.java
+++ b/src/org/jwildfire/create/tina/variation/PostHeatFunc.java
@@ -18,9 +18,8 @@ if not, write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor
 */
 
 import static org.jwildfire.base.mathlib.MathLib.M_2PI;
-import static org.jwildfire.base.mathlib.MathLib.M_PI;
 import static org.jwildfire.base.mathlib.MathLib.acos;
-import static org.jwildfire.base.mathlib.MathLib.atan;
+import static org.jwildfire.base.mathlib.MathLib.atan2;
 import static org.jwildfire.base.mathlib.MathLib.cos;
 import static org.jwildfire.base.mathlib.MathLib.sin;
 import static org.jwildfire.base.mathlib.MathLib.sqr;
@@ -85,13 +84,7 @@ public class PostHeatFunc extends VariationFunc {
 
     double sint, cost, sinp, cosp, atant, acosp;
 
-    // avoid dividing by zero
-    if (pVarTP.x != 0) {
-      atant = atan(pVarTP.y / pVarTP.x);
-    }
-    else {
-      atant = M_PI / 2.0;
-    }
+    atant = atan2(pVarTP.y, pVarTP.x);
 
     r += ar * sin(br * r + cr);
 
@@ -110,9 +103,9 @@ public class PostHeatFunc extends VariationFunc {
     cosp = cos(sinp);
     sinp = sin(sinp);
 
-    pVarTP.x += r * cost * sinp;
-    pVarTP.y += r * sint * sinp;
-    pVarTP.z += r * cosp;
+    pVarTP.x = r * cost * sinp;
+    pVarTP.y = r * sint * sinp;
+    pVarTP.z = r * cosp;
   }
 
   @Override

--- a/src/org/jwildfire/create/tina/variation/PostJulia3DQFunc.java
+++ b/src/org/jwildfire/create/tina/variation/PostJulia3DQFunc.java
@@ -49,10 +49,10 @@ public class PostJulia3DQFunc extends VariationFunc {
     double z = pVarTP.z * abs_inv_power;
     double r2d = sqr(pVarTP.x) + sqr(pVarTP.y);
     double r = pAmount * pow(r2d + sqr(z), half_inv_power);
-    pVarTP.z += r * z;
+    pVarTP.z = r * z;
     r *= sqrt(r2d);
-    pVarTP.x += r * cosa;
-    pVarTP.y += r * sina;
+    pVarTP.x = r * cosa;
+    pVarTP.y = r * sina;
   }
 
   @Override

--- a/src/org/jwildfire/create/tina/variation/PostJuliaQFunc.java
+++ b/src/org/jwildfire/create/tina/variation/PostJuliaQFunc.java
@@ -45,8 +45,8 @@ public class PostJuliaQFunc extends VariationFunc {
     double sina = sin(a);
     double cosa = cos(a);
     double r = pAmount * pow(sqr(pVarTP.x) + sqr(pVarTP.y), half_inv_power);
-    pVarTP.x += r * cosa;
-    pVarTP.y += r * sina;
+    pVarTP.x = r * cosa;
+    pVarTP.y = r * sina;
   }
 
   @Override

--- a/src/org/jwildfire/create/tina/variation/PostPointSymmetryWFFunc.java
+++ b/src/org/jwildfire/create/tina/variation/PostPointSymmetryWFFunc.java
@@ -44,9 +44,6 @@ public class PostPointSymmetryWFFunc extends VariationFunc {
     int idx = pContext.random(order);
     pVarTP.x = centre_x + dx * _cosa[idx] + dy * _sina[idx];
     pVarTP.y = centre_y + dy * _cosa[idx] - dx * _sina[idx];
-    if (pContext.isPreserveZCoordinate()) {
-      pVarTP.z += pAmount * pAffineTP.z;
-    }
   }
 
   @Override

--- a/src/org/jwildfire/create/tina/variation/PreBWraps2Func.java
+++ b/src/org/jwildfire/create/tina/variation/PreBWraps2Func.java
@@ -63,8 +63,8 @@ public class PreBWraps2Func extends VariationFunc {
 
     if (fabs(cellsize) < SMALL_EPSILON) {
       // Linear if cells are too small
-      pAffineTP.x += pAmount * Vx;
-      pAffineTP.y += pAmount * Vy;
+      pAffineTP.x = pAmount * Vx;
+      pAffineTP.y = pAmount * Vy;
       return;
     }
 
@@ -76,8 +76,8 @@ public class PreBWraps2Func extends VariationFunc {
 
     if ((Lx * Lx + Ly * Ly) > _r2) {
       // Linear if outside the bubble
-      pAffineTP.x += pAmount * Vx;
-      pAffineTP.y += pAmount * Vy;
+      pAffineTP.x = pAmount * Vx;
+      pAffineTP.y = pAmount * Vy;
       return;
     }
 
@@ -101,8 +101,8 @@ public class PreBWraps2Func extends VariationFunc {
     Vy = Cy - s * Lx + c * Ly;
 
     // Finally add values in
-    pAffineTP.x += pAmount * Vx;
-    pAffineTP.y += pAmount * Vy;
+    pAffineTP.x = pAmount * Vx;
+    pAffineTP.y = pAmount * Vy;
   }
 
   @Override
@@ -141,7 +141,7 @@ public class PreBWraps2Func extends VariationFunc {
     double radius = 0.5 * (cellsize / (1.0 + space * space));
 
     // g2 is multiplier for radius
-    _g2 = gain * gain + 1.0e-6;
+    _g2 = gain * gain / cellsize + 1.0e-6;
 
     // Start max_bubble as maximum x or y value before applying bubble
     double max_bubble = _g2 * radius;

--- a/src/org/jwildfire/create/tina/variation/PreBoarders2Func.java
+++ b/src/org/jwildfire/create/tina/variation/PreBoarders2Func.java
@@ -44,28 +44,28 @@ public class PreBoarders2Func extends VariationFunc {
     double offsetX = pAffineTP.x - roundX;
     double offsetY = pAffineTP.y - roundY;
     if (pContext.random() >= _cr) {
-      pAffineTP.x += pAmount * (offsetX * _c + roundX);
-      pAffineTP.y += pAmount * (offsetY * _c + roundY);
+      pAffineTP.x = pAmount * (offsetX * _c + roundX);
+      pAffineTP.y = pAmount * (offsetY * _c + roundY);
     }
     else {
       if (fabs(offsetX) >= fabs(offsetY)) {
         if (offsetX >= 0.0) {
-          pAffineTP.x += pAmount * (offsetX * _c + roundX + _cl);
-          pAffineTP.y += pAmount * (offsetY * _c + roundY + _cl * offsetY / offsetX);
+          pAffineTP.x = pAmount * (offsetX * _c + roundX + _cl);
+          pAffineTP.y = pAmount * (offsetY * _c + roundY + _cl * offsetY / offsetX);
         }
         else {
-          pAffineTP.x += pAmount * (offsetX * _c + roundX - _cl);
-          pAffineTP.y += pAmount * (offsetY * _c + roundY - _cl * offsetY / offsetX);
+          pAffineTP.x = pAmount * (offsetX * _c + roundX - _cl);
+          pAffineTP.y = pAmount * (offsetY * _c + roundY - _cl * offsetY / offsetX);
         }
       }
       else {
         if (offsetY >= 0.0) {
-          pAffineTP.y += pAmount * (offsetY * _c + roundY + _cl);
-          pAffineTP.x += pAmount * (offsetX * _c + roundX + offsetX / offsetY * _cl);
+          pAffineTP.y = pAmount * (offsetY * _c + roundY + _cl);
+          pAffineTP.x = pAmount * (offsetX * _c + roundX + offsetX / offsetY * _cl);
         }
         else {
-          pAffineTP.y += pAmount * (offsetY * _c + roundY - _cl);
-          pAffineTP.x += pAmount * (offsetX * _c + roundX - offsetX / offsetY * _cl);
+          pAffineTP.y = pAmount * (offsetY * _c + roundY - _cl);
+          pAffineTP.x = pAmount * (offsetX * _c + roundX - offsetX / offsetY * _cl);
         }
       }
     }

--- a/src/org/jwildfire/create/tina/variation/PreCircleCropFunc.java
+++ b/src/org/jwildfire/create/tina/variation/PreCircleCropFunc.java
@@ -57,8 +57,6 @@ public class PreCircleCropFunc extends VariationFunc {
     pAffineTP.x -= x0;
     pAffineTP.y -= y0;
 
-    pAffineTP.z += vv * pAffineTP.z;
-
     double rad = sqrt(pAffineTP.x * pAffineTP.x + pAffineTP.y * pAffineTP.y);
     double ang = atan2(pAffineTP.y, pAffineTP.x);
     double rdc = cr + (pContext.random() * 0.5 * ca);
@@ -75,16 +73,16 @@ public class PreCircleCropFunc extends VariationFunc {
       pAffineTP.doHide = true;
     }
     else if (cr0 && !esc) {
-      pAffineTP.x += vv * pAffineTP.x + x0;
-      pAffineTP.y += vv * pAffineTP.y + y0;
+      pAffineTP.x = vv * pAffineTP.x + x0;
+      pAffineTP.y = vv * pAffineTP.y + y0;
     }
     else if (!cr0 && esc) {
-      pAffineTP.x += vv * rdc * c + x0;
-      pAffineTP.y += vv * rdc * s + y0;
+      pAffineTP.x = vv * rdc * c + x0;
+      pAffineTP.y = vv * rdc * s + y0;
     }
     else if (!cr0 && !esc) {
-      pAffineTP.x += vv * pAffineTP.x + x0;
-      pAffineTP.y += vv * pAffineTP.y + y0;
+      pAffineTP.x = vv * pAffineTP.x + x0;
+      pAffineTP.y = vv * pAffineTP.y + y0;
     }
   }
 

--- a/src/org/jwildfire/create/tina/variation/PreDCZTranslFunc.java
+++ b/src/org/jwildfire/create/tina/variation/PreDCZTranslFunc.java
@@ -46,13 +46,13 @@ public class PreDCZTranslFunc extends VariationFunc {
     double zf = factor * (pAffineTP.color - _x0) / _x1_m_x0;
     if (clamp != 0)
       zf = zf < 0 ? 0 : zf > 1 ? 1 : zf;
-    pAffineTP.x += pAmount * pAffineTP.x;
-    pAffineTP.y += pAmount * pAffineTP.y;
+    pAffineTP.x = pAmount * pAffineTP.x;
+    pAffineTP.y = pAmount * pAffineTP.y;
 
     if (overwrite == 0)
-      pAffineTP.z += pAmount * pAffineTP.z * zf;
+      pAffineTP.z = pAmount * pAffineTP.z * zf;
     else
-      pAffineTP.z += pAmount * zf;
+      pAffineTP.z = pAmount * zf;
   }
 
   @Override

--- a/src/org/jwildfire/create/tina/variation/PreDisc3DFunc.java
+++ b/src/org/jwildfire/create/tina/variation/PreDisc3DFunc.java
@@ -42,9 +42,9 @@ public class PreDisc3DFunc extends VariationFunc {
     double sr = sin(a);
     double cr = cos(a);
     double vv = pAmount * atan2(pAffineTP.x, pAffineTP.y) / (this.pi + EPSILON);
-    pAffineTP.x += vv * sr;
-    pAffineTP.y += vv * cr;
-    pAffineTP.z += vv * (r * cos(pAffineTP.z));
+    pAffineTP.x = vv * sr;
+    pAffineTP.y = vv * cr;
+    pAffineTP.z = vv * (r * cos(pAffineTP.z));
   }
 
   @Override


### PR DESCRIPTION
Most pre and post variations should assign, not add their results. Fixed
this in multiple variations to match the original apo plugins. Found and
fixed a few other bugs while testing.