### PR TITLE
Add setBGTransparency line to scripts converted from flames

### DIFF
--- a/src/org/jwildfire/create/tina/script/swing/JWFScriptController.java
+++ b/src/org/jwildfire/create/tina/script/swing/JWFScriptController.java
@@ -424,6 +424,7 @@ public class JWFScriptController {
     sb.append("  flame.setHeight(" + pFlame.getHeight() + ");\n");
     sb.append("  flame.setPixelsPerUnit(" + Tools.doubleToString(pFlame.getPixelsPerUnit()) + ");\n");
     sb.append("  flame.setCamZoom(" + Tools.doubleToString(pFlame.getCamZoom()) + ");\n");
+    sb.append("  flame.setBGTransparency(" + pFlame.isBGTransparency() + ");\n");
     switch (pFlame.getPostSymmetryType()) {
       case POINT:
         sb.append("  flame.setPostSymmetryType(org.jwildfire.create.tina.base.PostSymmetryType." + pFlame.getPostSymmetryType().toString() + ");\n");


### PR DESCRIPTION
When a script creates a new flame, it sets bgTransparency to true by
default, so scripts converted from flames didn't preserve the setting
from the flame. Added a setBGTransparency call to do so.