### PR TITLE
Add getParameterAlternativeNames to minkowskope

### DIFF
--- a/src/org/jwildfire/create/tina/variation/MinkowskopeFunc.java
+++ b/src/org/jwildfire/create/tina/variation/MinkowskopeFunc.java
@@ -154,4 +154,11 @@ private double minkowski(double x) {
     _noDamping = fabs(damping) <= EPSILON;
     _altWave = frequencyx <= 0.0d;
   }
+  
+  @Override
+  public String[] getParameterAlternativeNames() {
+    return new String[] { "mskope_separation", "mskope_frequencyx", "mskope_frequencyy", "mskope_amplitude", "mskope_perturbation", "mskope_damping" };
+  }
+
 }
+


### PR DESCRIPTION
The Apophysis plugin version of minkowskope uses non-standard parameter
names, so added a getParameterAlternativeNames to be able to read
Apophysis flames that use it.