### PR TITLE
Add "invert" parameter to dc_bubble

### DIFF
--- a/src/org/jwildfire/create/tina/variation/ChecksFunc.java
+++ b/src/org/jwildfire/create/tina/variation/ChecksFunc.java
@@ -16,7 +16,7 @@
 */
 package org.jwildfire.create.tina.variation;
 
-import static org.jwildfire.base.mathlib.MathLib.EPSILON;
+import static org.jwildfire.base.mathlib.MathLib.SMALL_EPSILON;
 
 import org.jwildfire.create.tina.base.Layer;
 import org.jwildfire.create.tina.base.XForm;
@@ -100,7 +100,7 @@ public class ChecksFunc extends VariationFunc {
   @Override
   public void init(FlameTransformationContext pContext, Layer pLayer, XForm pXForm, double pAmount) {
     // Multiplication is faster than division, so divide in precalc, multiply in calc.
-    _cs = 1.0 / (size + EPSILON);
+    _cs = 1.0 / (size + SMALL_EPSILON);
     // -X- Then precalculate -checkx_x, -checks_y
     _ncx = x * -1.0;
     _ncy = y * -1.0;

--- a/src/org/jwildfire/create/tina/variation/CurlSpFunc.java
+++ b/src/org/jwildfire/create/tina/variation/CurlSpFunc.java
@@ -16,7 +16,7 @@
 */
 package org.jwildfire.create.tina.variation;
 
-import static org.jwildfire.base.mathlib.MathLib.EPSILON;
+import static org.jwildfire.base.mathlib.MathLib.SMALL_EPSILON;
 import static org.jwildfire.base.mathlib.MathLib.fabs;
 import static org.jwildfire.base.mathlib.MathLib.pow;
 import static org.jwildfire.base.mathlib.MathLib.sign;
@@ -110,7 +110,7 @@ public class CurlSpFunc extends VariationFunc {
     power_inv = 1.0 / zeps(power);
 
     if (power == 0) {
-      power = EPSILON;
+      power = SMALL_EPSILON;
     }
   }
 
@@ -131,7 +131,7 @@ public class CurlSpFunc extends VariationFunc {
   }
 
   private double zeps(double x) {
-    return ((x) == 0 ? EPSILON : (x));
+    return ((x) == 0 ? SMALL_EPSILON : (x));
   }
 
 }

--- a/src/org/jwildfire/create/tina/variation/DCBubbleFunc.java
+++ b/src/org/jwildfire/create/tina/variation/DCBubbleFunc.java
@@ -19,6 +19,7 @@ package org.jwildfire.create.tina.variation;
 import static org.jwildfire.base.mathlib.MathLib.fabs;
 import static org.jwildfire.base.mathlib.MathLib.fmod;
 import static org.jwildfire.base.mathlib.MathLib.sqr;
+import static org.jwildfire.base.Tools.limitValue;
 
 import org.jwildfire.create.tina.base.Layer;
 import org.jwildfire.create.tina.base.XForm;
@@ -31,22 +32,24 @@ public class DCBubbleFunc extends VariationFunc {
   private static final String PARAM_CENTERX = "centerx";
   private static final String PARAM_CENTERY = "centery";
   private static final String PARAM_SCALE = "scale";
+  private static final String PARAM_INVERT = "invert";
 
-  private static final String[] paramNames = { PARAM_CENTERX, PARAM_CENTERY, PARAM_SCALE };
+  private static final String[] paramNames = { PARAM_CENTERX, PARAM_CENTERY, PARAM_SCALE, PARAM_INVERT };
 
   private double centerx = 0.0;
   private double centery = 0.0;
   private double scale = 1.0;
+  private int invert = 1;
 
   @Override
   public void transform(FlameTransformationContext pContext, XForm pXForm, XYZPoint pAffineTP, XYZPoint pVarTP, double pAmount) {
-    /* dc_bubble by Xyrus02, http://apophysis-7x.org/extensions */
-    double r = (sqr(pAffineTP.x) + sqr(pAffineTP.y));
-    double r4_1 = r / 4.0 + 1.0;
-    r4_1 = pAmount / r4_1;
-    pVarTP.x += pVarTP.x + r4_1 * pAffineTP.x;
-    pVarTP.y += pVarTP.y + r4_1 * pAffineTP.y;
-    pVarTP.z += pVarTP.z + pAmount * (2.0 / r4_1 - 1.0);
+    /* corrected version of dc_bubble by Xyrus02, http://apophysis-7x.org/extensions */
+
+	double r = ((pAffineTP.x * pAffineTP.x + pAffineTP.y * pAffineTP.y) / 4.0 + 1.0);
+	double t = pAmount / r;
+	pVarTP.x += t * pAffineTP.x;
+	pVarTP.y += t * pAffineTP.y;
+	pVarTP.z += pAmount * (2.0 / (invert == 1 ? t : r) - 1.0);
 
     pVarTP.color = fmod(fabs(bdcs * (sqr(pVarTP.x + centerx) + sqr(pVarTP.y + centery))), 1.0);
   }
@@ -58,7 +61,7 @@ public class DCBubbleFunc extends VariationFunc {
 
   @Override
   public Object[] getParameterValues() {
-    return new Object[] { centerx, centery, scale };
+    return new Object[] { centerx, centery, scale, invert };
   }
 
   @Override
@@ -69,6 +72,8 @@ public class DCBubbleFunc extends VariationFunc {
       centery = pValue;
     else if (PARAM_SCALE.equalsIgnoreCase(pName))
       scale = pValue;
+    else if (PARAM_INVERT.equalsIgnoreCase(pName))
+      invert = limitValue((int) pValue, 0, 1);
     else
       throw new IllegalArgumentException(pName);
   }

--- a/src/org/jwildfire/create/tina/variation/DCPerlinFunc.java
+++ b/src/org/jwildfire/create/tina/variation/DCPerlinFunc.java
@@ -16,7 +16,7 @@
 */
 package org.jwildfire.create.tina.variation;
 
-import static org.jwildfire.base.mathlib.MathLib.EPSILON;
+import static org.jwildfire.base.mathlib.MathLib.SMALL_EPSILON;
 import static org.jwildfire.base.mathlib.MathLib.M_2PI;
 import static org.jwildfire.base.mathlib.MathLib.cos;
 import static org.jwildfire.base.mathlib.MathLib.floor;
@@ -132,7 +132,7 @@ public class DCPerlinFunc extends VariationFunc {
           break;
 
         case MAP_SPHERICAL:
-          r = 1.0 / (Vx * Vx + Vy * Vy + EPSILON);
+          r = 1.0 / (Vx * Vx + Vy * Vy + SMALL_EPSILON);
           V[0] = this.scale * Vx * r;
           V[1] = this.scale * Vy * r;
           V[2] = this.scale * this.z;

--- a/src/org/jwildfire/create/tina/variation/DCZTranslFunc.java
+++ b/src/org/jwildfire/create/tina/variation/DCZTranslFunc.java
@@ -16,7 +16,7 @@
 */
 package org.jwildfire.create.tina.variation;
 
-import static org.jwildfire.base.mathlib.MathLib.EPSILON;
+import static org.jwildfire.base.mathlib.MathLib.SMALL_EPSILON;
 
 import org.jwildfire.base.Tools;
 import org.jwildfire.create.tina.base.Layer;
@@ -94,7 +94,7 @@ public class DCZTranslFunc extends VariationFunc {
   public void init(FlameTransformationContext pContext, Layer pLayer, XForm pXForm, double pAmount) {
     _x0 = x0 < x1 ? x0 : x1;
     _x1 = x0 > x1 ? x0 : x1;
-    _x1_m_x0 = _x1 - _x0 == 0 ? EPSILON : _x1 - _x0;
+    _x1_m_x0 = _x1 - _x0 == 0 ? SMALL_EPSILON : _x1 - _x0;
   }
 
 }

--- a/src/org/jwildfire/create/tina/variation/Disc3DFunc.java
+++ b/src/org/jwildfire/create/tina/variation/Disc3DFunc.java
@@ -16,7 +16,7 @@
 */
 package org.jwildfire.create.tina.variation;
 
-import static org.jwildfire.base.mathlib.MathLib.EPSILON;
+import static org.jwildfire.base.mathlib.MathLib.SMALL_EPSILON;
 import static org.jwildfire.base.mathlib.MathLib.M_PI;
 import static org.jwildfire.base.mathlib.MathLib.atan2;
 import static org.jwildfire.base.mathlib.MathLib.cos;
@@ -38,11 +38,11 @@ public class Disc3DFunc extends VariationFunc {
   @Override
   public void transform(FlameTransformationContext pContext, XForm pXForm, XYZPoint pAffineTP, XYZPoint pVarTP, double pAmount) {
     /* disc3D by Larry Berlin, http://aporev.deviantart.com/art/3D-Plugins-Collection-One-138514007?q=gallery%3Aaporev%2F8229210&qo=15 */
-    double r = sqrt(pAffineTP.y * pAffineTP.y + pAffineTP.x * pAffineTP.x + EPSILON);
+    double r = sqrt(pAffineTP.y * pAffineTP.y + pAffineTP.x * pAffineTP.x + SMALL_EPSILON);
     double a = this.pi * r;
     double sr = sin(a);
     double cr = cos(a);
-    double vv = pAmount * atan2(pAffineTP.x, pAffineTP.y) / (this.pi + EPSILON);
+    double vv = pAmount * atan2(pAffineTP.x, pAffineTP.y) / (this.pi + SMALL_EPSILON);
     pVarTP.x += vv * sr;
     pVarTP.y += vv * cr;
     pVarTP.z += vv * (r * cos(pAffineTP.z));
@@ -69,12 +69,6 @@ public class Disc3DFunc extends VariationFunc {
   @Override
   public String getName() {
     return "disc3d";
-  }
-
-  @Override
-  public void init(FlameTransformationContext pContext, Layer pLayer, XForm pXForm, double pAmount) {
-    if (pi == 0)
-      pi = EPSILON;
   }
 
 }

--- a/src/org/jwildfire/create/tina/variation/EllipticFunc.java
+++ b/src/org/jwildfire/create/tina/variation/EllipticFunc.java
@@ -16,7 +16,7 @@
 */
 package org.jwildfire.create.tina.variation;
 
-import static org.jwildfire.base.mathlib.MathLib.EPSILON;
+import static org.jwildfire.base.mathlib.MathLib.SMALL_EPSILON;
 import static org.jwildfire.base.mathlib.MathLib.M_PI;
 import static org.jwildfire.base.mathlib.MathLib.atan2;
 import static org.jwildfire.base.mathlib.MathLib.log;
@@ -30,7 +30,7 @@ public class EllipticFunc extends SimpleVariationFunc {
   private static final long serialVersionUID = 1L;
 
   private double sqrt_safe(double x) {
-    return (x < EPSILON) ? 0.0 : sqrt(x);
+    return (x < SMALL_EPSILON) ? 0.0 : sqrt(x);
   }
 
   @Override

--- a/src/org/jwildfire/create/tina/variation/Fan2Func.java
+++ b/src/org/jwildfire/create/tina/variation/Fan2Func.java
@@ -16,7 +16,7 @@
 */
 package org.jwildfire.create.tina.variation;
 
-import static org.jwildfire.base.mathlib.MathLib.EPSILON;
+import static org.jwildfire.base.mathlib.MathLib.SMALL_EPSILON;
 import static org.jwildfire.base.mathlib.MathLib.M_PI;
 import static org.jwildfire.base.mathlib.MathLib.atan2;
 import static org.jwildfire.base.mathlib.MathLib.cos;
@@ -40,7 +40,7 @@ public class Fan2Func extends VariationFunc {
   public void transform(FlameTransformationContext pContext, XForm pXForm, XYZPoint pAffineTP, XYZPoint pVarTP, double pAmount) {
     double r = sqrt(pAffineTP.x * pAffineTP.x + pAffineTP.y * pAffineTP.y);
     double angle;
-    if ((pAffineTP.x < -EPSILON) || (pAffineTP.x > EPSILON) || (pAffineTP.y < -EPSILON) || (pAffineTP.y > EPSILON)) {
+    if ((pAffineTP.x < -SMALL_EPSILON) || (pAffineTP.x > SMALL_EPSILON) || (pAffineTP.y < -SMALL_EPSILON) || (pAffineTP.y > SMALL_EPSILON)) {
       angle = atan2(pAffineTP.x, pAffineTP.y);
     }
     else {
@@ -48,7 +48,7 @@ public class Fan2Func extends VariationFunc {
     }
 
     double dy = y;
-    double dx = M_PI * (x * x) + EPSILON;
+    double dx = M_PI * (x * x) + SMALL_EPSILON;
     double dx2 = dx * 0.5;
 
     double t = angle + dy - (int) ((angle + dy) / dx) * dx;

--- a/src/org/jwildfire/create/tina/variation/FociFunc.java
+++ b/src/org/jwildfire/create/tina/variation/FociFunc.java
@@ -16,7 +16,7 @@
 */
 package org.jwildfire.create.tina.variation;
 
-import static org.jwildfire.base.mathlib.MathLib.EPSILON;
+import static org.jwildfire.base.mathlib.MathLib.SMALL_EPSILON;
 import static org.jwildfire.base.mathlib.MathLib.cos;
 import static org.jwildfire.base.mathlib.MathLib.exp;
 import static org.jwildfire.base.mathlib.MathLib.sin;
@@ -33,7 +33,7 @@ public class FociFunc extends SimpleVariationFunc {
 
     double expx = exp(pAffineTP.x) * 0.5;
     double expnx = 0.25 / expx;
-    if (expx <= EPSILON || expnx <= EPSILON) {
+    if (expx <= SMALL_EPSILON || expnx <= SMALL_EPSILON) {
       return;
     }
     double siny = sin(pAffineTP.y);

--- a/src/org/jwildfire/create/tina/variation/JacCnFunc.java
+++ b/src/org/jwildfire/create/tina/variation/JacCnFunc.java
@@ -16,7 +16,7 @@
 */
 package org.jwildfire.create.tina.variation;
 
-import static org.jwildfire.base.mathlib.MathLib.EPSILON;
+import static org.jwildfire.base.mathlib.MathLib.SMALL_EPSILON;
 import static org.jwildfire.base.mathlib.MathLib.cos;
 import static org.jwildfire.base.mathlib.MathLib.cosh;
 import static org.jwildfire.base.mathlib.MathLib.fabs;
@@ -49,7 +49,7 @@ public class JacCnFunc extends VariationFunc {
     NumX = jac_x.cn * jac_y.cn;
     NumY = -jac_x.dn * jac_x.sn * jac_y.dn * jac_y.sn;
     Denom = sqr(jac_x.sn) * sqr(jac_y.sn) * k + sqr(jac_y.cn);
-    Denom = pAmount / (EPSILON + Denom);
+    Denom = pAmount / (SMALL_EPSILON + Denom);
     pVarTP.x += Denom * NumX;
     pVarTP.y += Denom * NumY;
     if (pContext.isPreserveZCoordinate()) {

--- a/src/org/jwildfire/create/tina/variation/JacDnFunc.java
+++ b/src/org/jwildfire/create/tina/variation/JacDnFunc.java
@@ -16,7 +16,7 @@
 */
 package org.jwildfire.create.tina.variation;
 
-import static org.jwildfire.base.mathlib.MathLib.EPSILON;
+import static org.jwildfire.base.mathlib.MathLib.SMALL_EPSILON;
 import static org.jwildfire.base.mathlib.MathLib.sqr;
 import static org.jwildfire.create.tina.variation.JacCnFunc.Jacobi_elliptic;
 
@@ -45,7 +45,7 @@ public class JacDnFunc extends VariationFunc {
     NumX = jac_x.dn * jac_y.cn * jac_y.dn;
     NumY = -jac_x.cn * jac_x.sn * jac_y.sn * k;
     Denom = sqr(jac_x.sn) * sqr(jac_y.sn) * k + sqr(jac_y.cn);
-    Denom = pAmount / (EPSILON + Denom);
+    Denom = pAmount / (SMALL_EPSILON + Denom);
     pVarTP.x += Denom * NumX;
     pVarTP.y += Denom * NumY;
     if (pContext.isPreserveZCoordinate()) {

--- a/src/org/jwildfire/create/tina/variation/JacSnFunc.java
+++ b/src/org/jwildfire/create/tina/variation/JacSnFunc.java
@@ -16,7 +16,7 @@
 */
 package org.jwildfire.create.tina.variation;
 
-import static org.jwildfire.base.mathlib.MathLib.EPSILON;
+import static org.jwildfire.base.mathlib.MathLib.SMALL_EPSILON;
 import static org.jwildfire.base.mathlib.MathLib.sqr;
 import static org.jwildfire.create.tina.variation.JacCnFunc.Jacobi_elliptic;
 
@@ -45,7 +45,7 @@ public class JacSnFunc extends VariationFunc {
     NumX = jac_x.sn * jac_y.dn;
     NumY = jac_x.cn * jac_x.dn * jac_y.cn * jac_y.sn;
     Denom = sqr(jac_x.sn) * sqr(jac_y.sn) * k + sqr(jac_y.cn);
-    Denom = pAmount / (EPSILON + Denom);
+    Denom = pAmount / (SMALL_EPSILON + Denom);
     pVarTP.x += Denom * NumX;
     pVarTP.y += Denom * NumY;
     if (pContext.isPreserveZCoordinate()) {

--- a/src/org/jwildfire/create/tina/variation/JuliaCFunc.java
+++ b/src/org/jwildfire/create/tina/variation/JuliaCFunc.java
@@ -16,7 +16,7 @@
 */
 package org.jwildfire.create.tina.variation;
 
-import static org.jwildfire.base.mathlib.MathLib.EPSILON;
+import static org.jwildfire.base.mathlib.MathLib.SMALL_EPSILON;
 import static org.jwildfire.base.mathlib.MathLib.M_PI;
 import static org.jwildfire.base.mathlib.MathLib.atan2;
 import static org.jwildfire.base.mathlib.MathLib.cos;
@@ -43,7 +43,7 @@ public class JuliaCFunc extends VariationFunc {
   @Override
   public void transform(FlameTransformationContext pContext, XForm pXForm, XYZPoint pAffineTP, XYZPoint pVarTP, double pAmount) {
     // juliac by David Young, http://sc0t0ma.deviantart.com/
-    double re = 1.0 / (this.re + EPSILON);
+    double re = 1.0 / (this.re + SMALL_EPSILON);
     double im = this.im / 100.0;
     double arg = atan2(pAffineTP.y, pAffineTP.x) + fmod(pContext.random(Integer.MAX_VALUE), this.re) * 2.0 * M_PI;
     double lnmod = dist * 0.5 * log(pAffineTP.x * pAffineTP.x + pAffineTP.y * pAffineTP.y);

--- a/src/org/jwildfire/create/tina/variation/Loonie3Func.java
+++ b/src/org/jwildfire/create/tina/variation/Loonie3Func.java
@@ -16,7 +16,7 @@
 */
 package org.jwildfire.create.tina.variation;
 
-import static org.jwildfire.base.mathlib.MathLib.EPSILON;
+import static org.jwildfire.base.mathlib.MathLib.SMALL_EPSILON;
 import static org.jwildfire.base.mathlib.MathLib.sqr;
 import static org.jwildfire.base.mathlib.MathLib.sqrt;
 
@@ -31,7 +31,7 @@ public class Loonie3Func extends SimpleVariationFunc {
   public void transform(FlameTransformationContext pContext, XForm pXForm, XYZPoint pAffineTP, XYZPoint pVarTP, double pAmount) {
     /* loonie2 by dark-beam, http://dark-beam.deviantart.com/art/Loonie2-update-2-Loonie3-457414891 */
     double r2 = 2 * _sqrvvar;
-    if (pAffineTP.x > EPSILON) {
+    if (pAffineTP.x > SMALL_EPSILON) {
       r2 = sqr((sqr(pAffineTP.x) + sqr(pAffineTP.y)) / pAffineTP.x);
     }
     if (r2 < _sqrvvar) {

--- a/src/org/jwildfire/create/tina/variation/OctagonFunc.java
+++ b/src/org/jwildfire/create/tina/variation/OctagonFunc.java
@@ -16,7 +16,7 @@
 */
 package org.jwildfire.create.tina.variation;
 
-import static org.jwildfire.base.mathlib.MathLib.EPSILON;
+import static org.jwildfire.base.mathlib.MathLib.SMALL_EPSILON;
 import static org.jwildfire.base.mathlib.MathLib.sqr;
 import static org.jwildfire.base.mathlib.MathLib.sqrt;
 
@@ -38,7 +38,7 @@ public class OctagonFunc extends VariationFunc {
   @Override
   public void transform(FlameTransformationContext pContext, XForm pXForm, XYZPoint pAffineTP, XYZPoint pVarTP, double pAmount) {
     /* octagon from FracFx, http://fracfx.deviantart.com/art/FracFx-Plugin-Pack-171806681 */
-    double r = pAmount / ((sqr(pAffineTP.x * pAffineTP.x) + sqr(pAffineTP.z) + sqr(pAffineTP.y * pAffineTP.y) + sqr(pAffineTP.z)) + EPSILON);
+    double r = pAmount / ((sqr(pAffineTP.x * pAffineTP.x) + sqr(pAffineTP.z) + sqr(pAffineTP.y * pAffineTP.y) + sqr(pAffineTP.z)) + SMALL_EPSILON);
     if (r < 2.0) {
       pVarTP.x += pAffineTP.x * r;
       pVarTP.y += pAffineTP.y * r;
@@ -51,7 +51,7 @@ public class OctagonFunc extends VariationFunc {
   pVarTP.z += pAmount * pAffineTP.z;
 }
     }
-    double t = pAmount / ((sqrt(pAffineTP.x * pAffineTP.x) + sqrt(pAffineTP.z) + sqrt(pAffineTP.y * pAffineTP.y) + sqrt(pAffineTP.z)) + EPSILON);
+    double t = pAmount / ((sqrt(pAffineTP.x * pAffineTP.x) + sqrt(pAffineTP.z) + sqrt(pAffineTP.y * pAffineTP.y) + sqrt(pAffineTP.z)) + SMALL_EPSILON);
     if (r >= 0) {
       pVarTP.x += pAffineTP.x * t;
       pVarTP.y += pAffineTP.y * t;

--- a/src/org/jwildfire/create/tina/variation/Ovoid3DFunc.java
+++ b/src/org/jwildfire/create/tina/variation/Ovoid3DFunc.java
@@ -16,7 +16,7 @@
 */
 package org.jwildfire.create.tina.variation;
 
-import static org.jwildfire.base.mathlib.MathLib.EPSILON;
+import static org.jwildfire.base.mathlib.MathLib.SMALL_EPSILON;
 
 import org.jwildfire.create.tina.base.XForm;
 import org.jwildfire.create.tina.base.XYZPoint;
@@ -36,7 +36,7 @@ public class Ovoid3DFunc extends VariationFunc {
   @Override
   public void transform(FlameTransformationContext pContext, XForm pXForm, XYZPoint pAffineTP, XYZPoint pVarTP, double pAmount) {
     // ovoid3d by Larry Berlin, http://aporev.deviantart.com/gallery/#/d2blmhg
-    double T = pAffineTP.x * pAffineTP.x + pAffineTP.y * pAffineTP.y + pAffineTP.z * pAffineTP.z + EPSILON;
+    double T = pAffineTP.x * pAffineTP.x + pAffineTP.y * pAffineTP.y + pAffineTP.z * pAffineTP.z + SMALL_EPSILON;
     double r = pAmount / T;
     pVarTP.x += pAffineTP.x * r * x;
     pVarTP.y += pAffineTP.y * r * y;

--- a/src/org/jwildfire/create/tina/variation/PostDCZTranslFunc.java
+++ b/src/org/jwildfire/create/tina/variation/PostDCZTranslFunc.java
@@ -16,7 +16,7 @@
 */
 package org.jwildfire.create.tina.variation;
 
-import static org.jwildfire.base.mathlib.MathLib.EPSILON;
+import static org.jwildfire.base.mathlib.MathLib.SMALL_EPSILON;
 
 import org.jwildfire.base.Tools;
 import org.jwildfire.create.tina.base.Layer;
@@ -101,7 +101,7 @@ public class PostDCZTranslFunc extends VariationFunc {
   public void init(FlameTransformationContext pContext, Layer pLayer, XForm pXForm, double pAmount) {
     _x0 = x0 < x1 ? x0 : x1;
     _x1 = x0 > x1 ? x0 : x1;
-    _x1_m_x0 = _x1 - _x0 == 0 ? EPSILON : _x1 - _x0;
+    _x1_m_x0 = _x1 - _x0 == 0 ? SMALL_EPSILON : _x1 - _x0;
   }
 
 }

--- a/src/org/jwildfire/create/tina/variation/PowBlockFunc.java
+++ b/src/org/jwildfire/create/tina/variation/PowBlockFunc.java
@@ -16,7 +16,7 @@
 */
 package org.jwildfire.create.tina.variation;
 
-import static org.jwildfire.base.mathlib.MathLib.EPSILON;
+import static org.jwildfire.base.mathlib.MathLib.SMALL_EPSILON;
 import static org.jwildfire.base.mathlib.MathLib.M_2PI;
 import static org.jwildfire.base.mathlib.MathLib.cos;
 import static org.jwildfire.base.mathlib.MathLib.fabs;
@@ -98,13 +98,13 @@ public class PowBlockFunc extends VariationFunc {
 
   @Override
   public void init(FlameTransformationContext pContext, Layer pLayer, XForm pXForm, double pAmount) {
-    _power = denominator * correctn * 1.0 / (fabs(correctd) + EPSILON);
-    if (fabs(_power) <= EPSILON)
-      _power = EPSILON;
+    _power = denominator * correctn * 1.0 / (fabs(correctd) + SMALL_EPSILON);
+    if (fabs(_power) <= SMALL_EPSILON)
+      _power = SMALL_EPSILON;
     _power = (numerator * 0.5) / _power;
     _deneps = denominator;
-    if (fabs(_deneps) <= EPSILON)
-      _deneps = EPSILON;
+    if (fabs(_deneps) <= SMALL_EPSILON)
+      _deneps = SMALL_EPSILON;
     _deneps = 1.0 / _deneps;
   }
 

--- a/src/org/jwildfire/create/tina/variation/PreDCZTranslFunc.java
+++ b/src/org/jwildfire/create/tina/variation/PreDCZTranslFunc.java
@@ -16,7 +16,7 @@
 */
 package org.jwildfire.create.tina.variation;
 
-import static org.jwildfire.base.mathlib.MathLib.EPSILON;
+import static org.jwildfire.base.mathlib.MathLib.SMALL_EPSILON;
 
 import org.jwildfire.base.Tools;
 import org.jwildfire.create.tina.base.Layer;
@@ -94,7 +94,7 @@ public class PreDCZTranslFunc extends VariationFunc {
   public void init(FlameTransformationContext pContext, Layer pLayer, XForm pXForm, double pAmount) {
     _x0 = x0 < x1 ? x0 : x1;
     _x1 = x0 > x1 ? x0 : x1;
-    _x1_m_x0 = _x1 - _x0 == 0 ? EPSILON : _x1 - _x0;
+    _x1_m_x0 = _x1 - _x0 == 0 ? SMALL_EPSILON : _x1 - _x0;
   }
 
   @Override

--- a/src/org/jwildfire/create/tina/variation/PreDisc3DFunc.java
+++ b/src/org/jwildfire/create/tina/variation/PreDisc3DFunc.java
@@ -16,7 +16,7 @@
 */
 package org.jwildfire.create.tina.variation;
 
-import static org.jwildfire.base.mathlib.MathLib.EPSILON;
+import static org.jwildfire.base.mathlib.MathLib.SMALL_EPSILON;
 import static org.jwildfire.base.mathlib.MathLib.M_PI;
 import static org.jwildfire.base.mathlib.MathLib.atan2;
 import static org.jwildfire.base.mathlib.MathLib.cos;
@@ -37,11 +37,11 @@ public class PreDisc3DFunc extends VariationFunc {
   @Override
   public void transform(FlameTransformationContext pContext, XForm pXForm, XYZPoint pAffineTP, XYZPoint pVarTP, double pAmount) {
     /* pre_disc by gossamer light */
-    double r = sqrt(pAffineTP.y * pAffineTP.y + pAffineTP.x * pAffineTP.x + EPSILON);
+    double r = sqrt(pAffineTP.y * pAffineTP.y + pAffineTP.x * pAffineTP.x + SMALL_EPSILON);
     double a = this.pi * r;
     double sr = sin(a);
     double cr = cos(a);
-    double vv = pAmount * atan2(pAffineTP.x, pAffineTP.y) / (this.pi + EPSILON);
+    double vv = pAmount * atan2(pAffineTP.x, pAffineTP.y) / (this.pi + SMALL_EPSILON);
     pAffineTP.x = vv * sr;
     pAffineTP.y = vv * cr;
     pAffineTP.z = vv * (r * cos(pAffineTP.z));

--- a/src/org/jwildfire/create/tina/variation/Rays2Func.java
+++ b/src/org/jwildfire/create/tina/variation/Rays2Func.java
@@ -16,7 +16,7 @@
 */
 package org.jwildfire.create.tina.variation;
 
-import static org.jwildfire.base.mathlib.MathLib.EPSILON;
+import static org.jwildfire.base.mathlib.MathLib.SMALL_EPSILON;
 import static org.jwildfire.base.mathlib.MathLib.cos;
 import static org.jwildfire.base.mathlib.MathLib.sqr;
 import static org.jwildfire.base.mathlib.MathLib.tan;
@@ -31,7 +31,7 @@ public class Rays2Func extends SimpleVariationFunc {
   public void transform(FlameTransformationContext pContext, XForm pXForm, XYZPoint pAffineTP, XYZPoint pVarTP, double pAmount) {
     // rays2 by Raykoid666, http://raykoid666.deviantart.com/art/re-pack-1-new-plugins-100092186 
     double t = sqr(pAffineTP.x) + sqr(pAffineTP.y);
-    double u = 1.0 / cos((t + EPSILON) * tan(1.0 / t + EPSILON));
+    double u = 1.0 / cos((t + SMALL_EPSILON) * tan(1.0 / t + SMALL_EPSILON));
 
     pVarTP.x = (pAmount / 10.0) * u * t / pAffineTP.x;
     pVarTP.y = (pAmount / 10.0) * u * t / pAffineTP.y;

--- a/src/org/jwildfire/create/tina/variation/Rays3Func.java
+++ b/src/org/jwildfire/create/tina/variation/Rays3Func.java
@@ -16,7 +16,7 @@
 */
 package org.jwildfire.create.tina.variation;
 
-import static org.jwildfire.base.mathlib.MathLib.EPSILON;
+import static org.jwildfire.base.mathlib.MathLib.SMALL_EPSILON;
 import static org.jwildfire.base.mathlib.MathLib.cos;
 import static org.jwildfire.base.mathlib.MathLib.sin;
 import static org.jwildfire.base.mathlib.MathLib.sqr;
@@ -33,7 +33,7 @@ public class Rays3Func extends SimpleVariationFunc {
   public void transform(FlameTransformationContext pContext, XForm pXForm, XYZPoint pAffineTP, XYZPoint pVarTP, double pAmount) {
     // rays3 by Raykoid666, http://raykoid666.deviantart.com/art/re-pack-1-new-plugins-100092186 
     double t = sqr(pAffineTP.x) + sqr(pAffineTP.y);
-    double u = 1.0 / sqrt(cos(sin(sqr(t) + EPSILON) * sin(1.0 / sqr(t) + EPSILON)));
+    double u = 1.0 / sqrt(cos(sin(sqr(t) + SMALL_EPSILON) * sin(1.0 / sqr(t) + SMALL_EPSILON)));
 
     pVarTP.x = (pAmount / 10.0) * u * cos(t) * t / pAffineTP.x;
     pVarTP.y = (pAmount / 10.0) * u * tan(t) * t / pAffineTP.y;

--- a/src/org/jwildfire/create/tina/variation/Rings2Func.java
+++ b/src/org/jwildfire/create/tina/variation/Rings2Func.java
@@ -16,7 +16,7 @@
 */
 package org.jwildfire.create.tina.variation;
 
-import static org.jwildfire.base.mathlib.MathLib.EPSILON;
+import static org.jwildfire.base.mathlib.MathLib.SMALL_EPSILON;
 
 import org.jwildfire.create.tina.base.Layer;
 import org.jwildfire.create.tina.base.XForm;
@@ -73,7 +73,7 @@ public class Rings2Func extends VariationFunc {
 
   @Override
   public void init(FlameTransformationContext pContext, Layer pLayer, XForm pXForm, double pAmount) {
-    _dx = val * val + EPSILON;
+    _dx = val * val + SMALL_EPSILON;
   }
 
 }

--- a/src/org/jwildfire/create/tina/variation/RippleFunc.java
+++ b/src/org/jwildfire/create/tina/variation/RippleFunc.java
@@ -16,7 +16,7 @@
 */
 package org.jwildfire.create.tina.variation;
 
-import static org.jwildfire.base.mathlib.MathLib.EPSILON;
+import static org.jwildfire.base.mathlib.MathLib.SMALL_EPSILON;
 import static org.jwildfire.base.mathlib.MathLib.M_2PI;
 import static org.jwildfire.base.mathlib.MathLib.M_PI;
 import static org.jwildfire.base.mathlib.MathLib.cos;
@@ -58,8 +58,8 @@ public class RippleFunc extends VariationFunc {
 
     // calculate distance from center but constrain it to EPS
     double d = _fixed_dist_calc ? sqrt(x * x + y * y) : sqrt(x * x * y * y);
-    if (d < EPSILON)
-      d = EPSILON;
+    if (d < SMALL_EPSILON)
+      d = SMALL_EPSILON;
 
     // normalize (x,y)
     double nx = x / d, ny = y / d;
@@ -134,7 +134,7 @@ public class RippleFunc extends VariationFunc {
     _p = phase * M_2PI - M_PI;
 
     // scale must not be zero
-    _s = scale == 0 ? EPSILON : scale;
+    _s = scale == 0 ? SMALL_EPSILON : scale;
 
     // we will need the inverse scale
     _is = 1.0 / _s;

--- a/src/org/jwildfire/create/tina/variation/RippledFunc.java
+++ b/src/org/jwildfire/create/tina/variation/RippledFunc.java
@@ -16,7 +16,7 @@
 */
 package org.jwildfire.create.tina.variation;
 
-import static org.jwildfire.base.mathlib.MathLib.EPSILON;
+import static org.jwildfire.base.mathlib.MathLib.SMALL_EPSILON;
 import static org.jwildfire.base.mathlib.MathLib.cos;
 import static org.jwildfire.base.mathlib.MathLib.sqr;
 import static org.jwildfire.base.mathlib.MathLib.tanh;
@@ -31,8 +31,8 @@ public class RippledFunc extends SimpleVariationFunc {
   public void transform(FlameTransformationContext pContext, XForm pXForm, XYZPoint pAffineTP, XYZPoint pVarTP, double pAmount) {
     // rippled by Raykoid666, http://raykoid666.deviantart.com/art/plugin-pack-3-100510461?q=gallery%3ARaykoid666%2F11060240&qo=16
     double d = sqr(pAffineTP.x) + sqr(pAffineTP.y);
-    pVarTP.x += pAmount / 2 * (tanh(d + EPSILON) * (2.0 * pAffineTP.x));
-    pVarTP.y += pAmount / 2 * (cos(d + EPSILON) * (2.0 * pAffineTP.y));
+    pVarTP.x += pAmount / 2 * (tanh(d + SMALL_EPSILON) * (2.0 * pAffineTP.x));
+    pVarTP.y += pAmount / 2 * (cos(d + SMALL_EPSILON) * (2.0 * pAffineTP.y));
     if (pContext.isPreserveZCoordinate()) {
   pVarTP.z += pAmount * pAffineTP.z;
 }

--- a/src/org/jwildfire/create/tina/variation/Scry3DFunc.java
+++ b/src/org/jwildfire/create/tina/variation/Scry3DFunc.java
@@ -16,7 +16,7 @@
 */
 package org.jwildfire.create.tina.variation;
 
-import static org.jwildfire.base.mathlib.MathLib.EPSILON;
+import static org.jwildfire.base.mathlib.MathLib.SMALL_EPSILON;
 import static org.jwildfire.base.mathlib.MathLib.atan2;
 import static org.jwildfire.base.mathlib.MathLib.sqr;
 import static org.jwildfire.base.mathlib.MathLib.sqrt;
@@ -30,7 +30,7 @@ public class Scry3DFunc extends SimpleVariationFunc {
   @Override
   public void transform(FlameTransformationContext pContext, XForm pXForm, XYZPoint pAffineTP, XYZPoint pVarTP, double pAmount) {
     /* scry_3D by Larry Berlin, http://aporev.deviantart.com/art/New-3D-Plugins-136484533?q=gallery%3Aaporev%2F8229210&qo=22 */
-    double inv = 1.0 / (pAmount + EPSILON);
+    double inv = 1.0 / (pAmount + SMALL_EPSILON);
     double t = sqr(pAffineTP.x) + sqr(pAffineTP.y) + sqr(pAffineTP.z);
     double r = 1.0 / (sqrt(t) * (t + inv));
     double Footzee, kikr;

--- a/src/org/jwildfire/create/tina/variation/ShredradFunc.java
+++ b/src/org/jwildfire/create/tina/variation/ShredradFunc.java
@@ -18,7 +18,7 @@ package org.jwildfire.create.tina.variation;
 
 import static org.jwildfire.base.mathlib.MathLib.sin;
 import static org.jwildfire.base.mathlib.MathLib.cos;
-import static org.jwildfire.base.mathlib.MathLib.EPSILON;
+import static org.jwildfire.base.mathlib.MathLib.SMALL_EPSILON;
 import static org.jwildfire.base.mathlib.MathLib.M_PI;
 import static org.jwildfire.base.mathlib.MathLib.M_2PI;
 
@@ -72,7 +72,7 @@ public class ShredradFunc extends VariationFunc {
   @Override
   public void setParameter(String pName, double pValue) {
     if (PARAM_N.equalsIgnoreCase(pName)) {
-      n = (pValue==0) ? EPSILON : pValue;
+      n = (pValue==0) ? SMALL_EPSILON : pValue;
       alpha = M_2PI / n;
     }
     else if (PARAM_WIDTH.equalsIgnoreCase(pName))

--- a/src/org/jwildfire/create/tina/variation/SigmoidFunc.java
+++ b/src/org/jwildfire/create/tina/variation/SigmoidFunc.java
@@ -37,7 +37,7 @@ public class SigmoidFunc extends VariationFunc {
 	  double sy = shifty;
 	    if (sx < 1 && sx > -1) {
 	       if (sx == 0) {
-	          sx = EPSILON; ax = 1.0;
+	          sx = SMALL_EPSILON; ax = 1.0;
 	       } else {
 	         ax = (sx < 0 ? -1 : 1);
 	         sx = 1 / sx;
@@ -45,7 +45,7 @@ public class SigmoidFunc extends VariationFunc {
 	    }
 	    if (sy < 1 && sy > -1) {
 	       if (sy == 0) {
-	          sy = EPSILON; ay = 1.0;
+	          sy = SMALL_EPSILON; ay = 1.0;
 	       } else {
 	         ay = (sy < 0 ? -1 : 1);
 	         sy = 1 / sy;

--- a/src/org/jwildfire/create/tina/variation/SphericalFunc.java
+++ b/src/org/jwildfire/create/tina/variation/SphericalFunc.java
@@ -16,7 +16,7 @@
 */
 package org.jwildfire.create.tina.variation;
 
-import static org.jwildfire.base.mathlib.MathLib.EPSILON;
+import static org.jwildfire.base.mathlib.MathLib.SMALL_EPSILON;
 
 import org.jwildfire.create.tina.base.XForm;
 import org.jwildfire.create.tina.base.XYZPoint;
@@ -26,7 +26,7 @@ public class SphericalFunc extends SimpleVariationFunc {
 
   @Override
   public void transform(FlameTransformationContext pContext, XForm pXForm, XYZPoint pAffineTP, XYZPoint pVarTP, double pAmount) {
-    double r = pAmount / (pAffineTP.x * pAffineTP.x + pAffineTP.y * pAffineTP.y + EPSILON);
+    double r = pAmount / (pAffineTP.x * pAffineTP.x + pAffineTP.y * pAffineTP.y + SMALL_EPSILON);
     pVarTP.x += pAffineTP.x * r;
     pVarTP.y += pAffineTP.y * r;
     if (pContext.isPreserveZCoordinate()) {

--- a/src/org/jwildfire/create/tina/variation/SphericalNFunc.java
+++ b/src/org/jwildfire/create/tina/variation/SphericalNFunc.java
@@ -16,7 +16,7 @@
 */
 package org.jwildfire.create.tina.variation;
 
-import static org.jwildfire.base.mathlib.MathLib.EPSILON;
+import static org.jwildfire.base.mathlib.MathLib.SMALL_EPSILON;
 import static org.jwildfire.base.mathlib.MathLib.M_2PI;
 import static org.jwildfire.base.mathlib.MathLib.atan2;
 import static org.jwildfire.base.mathlib.MathLib.cos;
@@ -51,7 +51,7 @@ public class SphericalNFunc extends VariationFunc {
     double sina = sin(alpha);
     double cosa = cos(alpha);
 
-    if (R > EPSILON) {
+    if (R > SMALL_EPSILON) {
       pVarTP.x += pAmount * cosa / R;
       pVarTP.y += pAmount * sina / R;
     }

--- a/src/org/jwildfire/create/tina/variation/SpiralwingFunc.java
+++ b/src/org/jwildfire/create/tina/variation/SpiralwingFunc.java
@@ -16,7 +16,7 @@
 */
 package org.jwildfire.create.tina.variation;
 
-import static org.jwildfire.base.mathlib.MathLib.EPSILON;
+import static org.jwildfire.base.mathlib.MathLib.SMALL_EPSILON;
 import static org.jwildfire.base.mathlib.MathLib.cos;
 import static org.jwildfire.base.mathlib.MathLib.sin;
 import static org.jwildfire.base.mathlib.MathLib.sqr;
@@ -32,7 +32,7 @@ public class SpiralwingFunc extends SimpleVariationFunc {
     // spiralwing by Raykoid666, http://raykoid666.deviantart.com/art/re-pack-1-new-plugins-100092186 
     double c1 = sqr(pAffineTP.x);
     double c2 = sqr(pAffineTP.y);
-    double d = pAmount / (c1 + c2 + EPSILON);
+    double d = pAmount / (c1 + c2 + SMALL_EPSILON);
     c2 = sin(c2); // speedup
 
     pVarTP.x += d * cos(c1) * c2;

--- a/src/org/jwildfire/create/tina/variation/SplipticBSFunc.java
+++ b/src/org/jwildfire/create/tina/variation/SplipticBSFunc.java
@@ -16,7 +16,7 @@
 */
 package org.jwildfire.create.tina.variation;
 
-import static org.jwildfire.base.mathlib.MathLib.EPSILON;
+import static org.jwildfire.base.mathlib.MathLib.SMALL_EPSILON;
 import static org.jwildfire.base.mathlib.MathLib.M_PI;
 import static org.jwildfire.base.mathlib.MathLib.atan2;
 import static org.jwildfire.base.mathlib.MathLib.log;
@@ -36,7 +36,7 @@ public class SplipticBSFunc extends VariationFunc {
   private double y = 0.05;
 
   private double sqrt_safe(double x) {
-    return (x < EPSILON) ? 0.0 : sqrt(x);
+    return (x < SMALL_EPSILON) ? 0.0 : sqrt(x);
   }
 
   @Override

--- a/src/org/jwildfire/create/tina/variation/SynthFunc.java
+++ b/src/org/jwildfire/create/tina/variation/SynthFunc.java
@@ -16,7 +16,7 @@
 */
 package org.jwildfire.create.tina.variation;
 
-import static org.jwildfire.base.mathlib.MathLib.EPSILON;
+import static org.jwildfire.base.mathlib.MathLib.SMALL_EPSILON;
 import static org.jwildfire.base.mathlib.MathLib.M_PI;
 import static org.jwildfire.base.mathlib.MathLib.asin;
 import static org.jwildfire.base.mathlib.MathLib.atan2;
@@ -742,7 +742,7 @@ public class SynthFunc extends VariationFunc {
   private static final int SINCOS_MULTIPLY = 0;
   private static final int SINCOS_MIXIN = 1;
 
-  private static final double EPS = EPSILON;
+  private static final double EPS = SMALL_EPSILON;
 
   // -------------------------------------------------------------
   // synth_value calculates the wave height y from theta, which is an abstract

--- a/src/org/jwildfire/create/tina/variation/TanCosFunc.java
+++ b/src/org/jwildfire/create/tina/variation/TanCosFunc.java
@@ -16,7 +16,7 @@
 */
 package org.jwildfire.create.tina.variation;
 
-import static org.jwildfire.base.mathlib.MathLib.EPSILON;
+import static org.jwildfire.base.mathlib.MathLib.SMALL_EPSILON;
 import static org.jwildfire.base.mathlib.MathLib.cos;
 import static org.jwildfire.base.mathlib.MathLib.sqr;
 import static org.jwildfire.base.mathlib.MathLib.tanh;
@@ -30,7 +30,7 @@ public class TanCosFunc extends SimpleVariationFunc {
   @Override
   public void transform(FlameTransformationContext pContext, XForm pXForm, XYZPoint pAffineTP, XYZPoint pVarTP, double pAmount) {
     // tancos by Raykoid666, http://raykoid666.deviantart.com/art/plugin-pack-3-100510461?q=gallery%3ARaykoid666%2F11060240&qo=16
-    double d1 = EPSILON + sqr(pAffineTP.x) + sqr(pAffineTP.y);
+    double d1 = SMALL_EPSILON + sqr(pAffineTP.x) + sqr(pAffineTP.y);
     double d2 = pAmount / d1;
     pVarTP.x += d2 * (tanh(d1) * (2.0 * pAffineTP.x));
     pVarTP.y += d2 * (cos(d1) * (2.0 * pAffineTP.y));

--- a/src/org/jwildfire/create/tina/variation/WFunc.java
+++ b/src/org/jwildfire/create/tina/variation/WFunc.java
@@ -16,7 +16,7 @@
 */
 package org.jwildfire.create.tina.variation;
 
-import static org.jwildfire.base.mathlib.MathLib.EPSILON;
+import static org.jwildfire.base.mathlib.MathLib.SMALL_EPSILON;
 import static org.jwildfire.base.mathlib.MathLib.M_2PI;
 import static org.jwildfire.base.mathlib.MathLib.M_PI;
 import static org.jwildfire.base.mathlib.MathLib.atan2;
@@ -221,7 +221,7 @@ public class WFunc extends VariationFunc {
     _star_slope = tan(star_slope);
 
     _super_m = super_m / 4.0;
-    _super_n1 = -1.0 / (super_n1 + EPSILON);
+    _super_n1 = -1.0 / (super_n1 + SMALL_EPSILON);
 
   }
 

--- a/src/org/jwildfire/create/tina/variation/WavesFunc.java
+++ b/src/org/jwildfire/create/tina/variation/WavesFunc.java
@@ -16,7 +16,7 @@
 */
 package org.jwildfire.create.tina.variation;
 
-import static org.jwildfire.base.mathlib.MathLib.EPSILON;
+import static org.jwildfire.base.mathlib.MathLib.SMALL_EPSILON;
 import static org.jwildfire.base.mathlib.MathLib.sin;
 
 import org.jwildfire.create.tina.base.XForm;
@@ -27,8 +27,8 @@ public class WavesFunc extends SimpleVariationFunc {
 
   @Override
   public void transform(FlameTransformationContext pContext, XForm pXForm, XYZPoint pAffineTP, XYZPoint pVarTP, double pAmount) {
-    pVarTP.x += pAmount * (pAffineTP.x + pXForm.getXYCoeff10() * sin(pAffineTP.y / (pXForm.getXYCoeff20() * pXForm.getXYCoeff20() + EPSILON)));
-    pVarTP.y += pAmount * (pAffineTP.y + pXForm.getXYCoeff11() * sin(pAffineTP.x / (pXForm.getXYCoeff21() * pXForm.getXYCoeff21() + EPSILON)));
+    pVarTP.x += pAmount * (pAffineTP.x + pXForm.getXYCoeff10() * sin(pAffineTP.y / (pXForm.getXYCoeff20() * pXForm.getXYCoeff20() + SMALL_EPSILON)));
+    pVarTP.y += pAmount * (pAffineTP.y + pXForm.getXYCoeff11() * sin(pAffineTP.x / (pXForm.getXYCoeff21() * pXForm.getXYCoeff21() + SMALL_EPSILON)));
     if (pContext.isPreserveZCoordinate()) {
   pVarTP.z += pAmount * pAffineTP.z;
 }

--- a/src/org/jwildfire/create/tina/variation/WedgeSphFunc.java
+++ b/src/org/jwildfire/create/tina/variation/WedgeSphFunc.java
@@ -16,7 +16,7 @@
 */
 package org.jwildfire.create.tina.variation;
 
-import static org.jwildfire.base.mathlib.MathLib.EPSILON;
+import static org.jwildfire.base.mathlib.MathLib.SMALL_EPSILON;
 import static org.jwildfire.base.mathlib.MathLib.M_1_PI;
 import static org.jwildfire.base.mathlib.MathLib.M_PI;
 import static org.jwildfire.base.mathlib.MathLib.cos;
@@ -45,7 +45,7 @@ public class WedgeSphFunc extends VariationFunc {
   public void transform(FlameTransformationContext pContext, XForm pXForm, XYZPoint pAffineTP, XYZPoint pVarTP, double pAmount) {
     /* Wedge_sph from apo plugins pack */
 
-    double r = 1.0 / (pAffineTP.getPrecalcSqrt() + EPSILON);
+    double r = 1.0 / (pAffineTP.getPrecalcSqrt() + SMALL_EPSILON);
     double a = pAffineTP.getPrecalcAtanYX() + swirl * r;
     double c = floor((count * a + M_PI) * M_1_PI * 0.5);
 

--- a/src/org/jwildfire/create/tina/variation/XErfFunc.java
+++ b/src/org/jwildfire/create/tina/variation/XErfFunc.java
@@ -32,7 +32,7 @@ public class XErfFunc extends SimpleVariationFunc {
       // "xerf" variation created by zephyrtronium implemented into JWildfire by darkbeam
 
     double r2 = sqr(sqrt(sqr(pAffineTP.x) + sqr(pAffineTP.y) + sqr(pAffineTP.z))); // sqr sqrt??? whatever
-    if (r2 <=EPSILON) r2 = EPSILON; // no overflow fix by Dark
+    if (r2 <=SMALL_EPSILON) r2 = SMALL_EPSILON; // no overflow fix by Dark
 
     pVarTP.x += ( (fabs(pAffineTP.x) >= 2.0) ? (pAffineTP.x / r2 ): erf(pAffineTP.x)) * pAmount;
     pVarTP.y += ( (fabs(pAffineTP.y) >= 2.0) ? (pAffineTP.y / r2 ): erf(pAffineTP.y)) * pAmount;

--- a/src/org/jwildfire/create/tina/variation/XFunc.java
+++ b/src/org/jwildfire/create/tina/variation/XFunc.java
@@ -16,7 +16,7 @@
 */
 package org.jwildfire.create.tina.variation;
 
-import static org.jwildfire.base.mathlib.MathLib.EPSILON;
+import static org.jwildfire.base.mathlib.MathLib.SMALL_EPSILON;
 import static org.jwildfire.base.mathlib.MathLib.M_2PI;
 import static org.jwildfire.base.mathlib.MathLib.M_PI;
 import static org.jwildfire.base.mathlib.MathLib.atan2;
@@ -177,7 +177,7 @@ public class XFunc extends VariationFunc {
     _star_slope = tan(star_slope);
 
     _super_m = super_m / 4.0;
-    _super_n1 = -1.0 / (super_n1 + EPSILON);
+    _super_n1 = -1.0 / (super_n1 + SMALL_EPSILON);
 
   }
 

--- a/src/org/jwildfire/create/tina/variation/YFunc.java
+++ b/src/org/jwildfire/create/tina/variation/YFunc.java
@@ -16,7 +16,7 @@
 */
 package org.jwildfire.create.tina.variation;
 
-import static org.jwildfire.base.mathlib.MathLib.EPSILON;
+import static org.jwildfire.base.mathlib.MathLib.SMALL_EPSILON;
 import static org.jwildfire.base.mathlib.MathLib.M_2PI;
 import static org.jwildfire.base.mathlib.MathLib.M_PI;
 import static org.jwildfire.base.mathlib.MathLib.atan2;
@@ -177,7 +177,7 @@ public class YFunc extends VariationFunc {
     _star_slope = tan(star_slope);
 
     _super_m = super_m / 4.0;
-    _super_n1 = -1.0 / (super_n1 + EPSILON);
+    _super_n1 = -1.0 / (super_n1 + SMALL_EPSILON);
 
   }
 

--- a/src/org/jwildfire/create/tina/variation/ZFunc.java
+++ b/src/org/jwildfire/create/tina/variation/ZFunc.java
@@ -16,7 +16,7 @@
 */
 package org.jwildfire.create.tina.variation;
 
-import static org.jwildfire.base.mathlib.MathLib.EPSILON;
+import static org.jwildfire.base.mathlib.MathLib.SMALL_EPSILON;
 import static org.jwildfire.base.mathlib.MathLib.M_2PI;
 import static org.jwildfire.base.mathlib.MathLib.M_PI;
 import static org.jwildfire.base.mathlib.MathLib.atan2;
@@ -177,7 +177,7 @@ public class ZFunc extends VariationFunc {
     _star_slope = tan(star_slope);
 
     _super_m = super_m / 4.0;
-    _super_n1 = -1.0 / (super_n1 + EPSILON);
+    _super_n1 = -1.0 / (super_n1 + SMALL_EPSILON);
 
   }
 


### PR DESCRIPTION
This fixes a bug from the original apophysis plugin that was faithfully
copied to the JWildfire version. Default is 1 for compatibility, which
reproduces the behavior of the plugin. Change to 0 to make it work
properly, like bubble but with direct coloring.