### PR TITLE
Revert SMALL_EPSILON change for "stepping" variations

### DIFF
--- a/src/org/jwildfire/create/tina/variation/ChecksFunc.java
+++ b/src/org/jwildfire/create/tina/variation/ChecksFunc.java
@@ -16,7 +16,7 @@
 */
 package org.jwildfire.create.tina.variation;
 
-import static org.jwildfire.base.mathlib.MathLib.SMALL_EPSILON;
+import static org.jwildfire.base.mathlib.MathLib.EPSILON;
 
 import org.jwildfire.create.tina.base.Layer;
 import org.jwildfire.create.tina.base.XForm;
@@ -100,7 +100,7 @@ public class ChecksFunc extends VariationFunc {
   @Override
   public void init(FlameTransformationContext pContext, Layer pLayer, XForm pXForm, double pAmount) {
     // Multiplication is faster than division, so divide in precalc, multiply in calc.
-    _cs = 1.0 / (size + SMALL_EPSILON);
+    _cs = 1.0 / (size + EPSILON);
     // -X- Then precalculate -checkx_x, -checks_y
     _ncx = x * -1.0;
     _ncy = y * -1.0;

--- a/src/org/jwildfire/create/tina/variation/Rings2Func.java
+++ b/src/org/jwildfire/create/tina/variation/Rings2Func.java
@@ -16,7 +16,7 @@
 */
 package org.jwildfire.create.tina.variation;
 
-import static org.jwildfire.base.mathlib.MathLib.SMALL_EPSILON;
+import static org.jwildfire.base.mathlib.MathLib.EPSILON;
 
 import org.jwildfire.create.tina.base.Layer;
 import org.jwildfire.create.tina.base.XForm;
@@ -73,7 +73,7 @@ public class Rings2Func extends VariationFunc {
 
   @Override
   public void init(FlameTransformationContext pContext, Layer pLayer, XForm pXForm, double pAmount) {
-    _dx = val * val + SMALL_EPSILON;
+    _dx = val * val + EPSILON;
   }
 
 }

--- a/src/org/jwildfire/create/tina/variation/ShredradFunc.java
+++ b/src/org/jwildfire/create/tina/variation/ShredradFunc.java
@@ -18,7 +18,7 @@ package org.jwildfire.create.tina.variation;
 
 import static org.jwildfire.base.mathlib.MathLib.sin;
 import static org.jwildfire.base.mathlib.MathLib.cos;
-import static org.jwildfire.base.mathlib.MathLib.SMALL_EPSILON;
+import static org.jwildfire.base.mathlib.MathLib.EPSILON;
 import static org.jwildfire.base.mathlib.MathLib.M_PI;
 import static org.jwildfire.base.mathlib.MathLib.M_2PI;
 
@@ -72,7 +72,7 @@ public class ShredradFunc extends VariationFunc {
   @Override
   public void setParameter(String pName, double pValue) {
     if (PARAM_N.equalsIgnoreCase(pName)) {
-      n = (pValue==0) ? SMALL_EPSILON : pValue;
+      n = (pValue==0) ? EPSILON : pValue;
       alpha = M_2PI / n;
     }
     else if (PARAM_WIDTH.equalsIgnoreCase(pName))


### PR DESCRIPTION
The previous change of EPSILON to SMALL_EPSILON broke three variations:
checks, rings2, and shredrad, which create "steps" in the fractal by
truncating part of the calculation. So changed back to EPSILON for these
variations.