### PR TITLE
Some changes to apocarpet, htree & rsquares variations

### DIFF
--- a/src/org/jwildfire/create/tina/variation/ApocarpetFunc.java
+++ b/src/org/jwildfire/create/tina/variation/ApocarpetFunc.java
@@ -75,6 +75,10 @@ public class ApocarpetFunc extends SimpleVariationFunc {
                 
 				pVarTP.x += x*pAmount;
 				pVarTP.y += y*pAmount;
+			    if (pContext.isPreserveZCoordinate())
+			    {
+			        pVarTP.z += pAmount * pAffineTP.z;
+			    }
 
 //			    pVarTP.color = fmod(fabs( (sqr(pVarTP.x) + sqr(pVarTP.y ))), 1.0);
 			  }

--- a/src/org/jwildfire/create/tina/variation/HtreeFunc.java
+++ b/src/org/jwildfire/create/tina/variation/HtreeFunc.java
@@ -40,7 +40,7 @@ import java.util.Arrays;
 import org.jwildfire.create.tina.base.Layer;
 import org.jwildfire.create.tina.base.XForm;
 import org.jwildfire.create.tina.base.XYZPoint;
-import org.jwildfire.create.tina.variation.HilbertFunc.DoublePoint2D;
+
 
 
 

--- a/src/org/jwildfire/create/tina/variation/RsquaresFunc.java
+++ b/src/org/jwildfire/create/tina/variation/RsquaresFunc.java
@@ -38,7 +38,6 @@ import java.util.Arrays;
 import org.jwildfire.create.tina.base.Layer;
 import org.jwildfire.create.tina.base.XForm;
 import org.jwildfire.create.tina.base.XYZPoint;
-import org.jwildfire.create.tina.variation.HilbertFunc.DoublePoint2D;
 
 public class RsquaresFunc extends VariationFunc {
 	


### PR DESCRIPTION
htree & rsquares remove dependence on Hilbert variation.

Apocarpet: added if (pContext.isPreserveZCoordinate()) {
     pVarTP.z += pAmount* pAffineTP.z;
    }