### PR TITLE
Fixed compilation errors by removing non-UTF-8 characters (UTF-16 und…

### DIFF
--- a/src/org/jwildfire/create/tina/variation/BrownianFunc.java
+++ b/src/org/jwildfire/create/tina/variation/BrownianFunc.java
@@ -133,7 +133,7 @@ public class BrownianFunc extends VariationFunc {
 	  return size == 0;
 	}
 
-	// Checks if the given index is in range.  
+	// Checks if the given index is in range.
 	private void rangeCheck(int index)
 	{
 	  if (index >= size || index < 0)

--- a/src/org/jwildfire/create/tina/variation/DragonFunc.java
+++ b/src/org/jwildfire/create/tina/variation/DragonFunc.java
@@ -102,7 +102,7 @@ public class DragonFunc extends VariationFunc {
 	  return size == 0;
 	}
 
-	// Checks if the given index is in range.  
+	// Checks if the given index is in range.
 	private void rangeCheck(int index)
 	{
 	  if (index >= size || index < 0)

--- a/src/org/jwildfire/create/tina/variation/GosperIslandFunc.java
+++ b/src/org/jwildfire/create/tina/variation/GosperIslandFunc.java
@@ -102,7 +102,7 @@ public class GosperIslandFunc extends VariationFunc {
 	  return size == 0;
 	}
 
-	// Checks if the given index is in range.  
+	// Checks if the given index is in range.
 	private void rangeCheck(int index)
 	{
 	  if (index >= size || index < 0)

--- a/src/org/jwildfire/create/tina/variation/HilbertFunc.java
+++ b/src/org/jwildfire/create/tina/variation/HilbertFunc.java
@@ -126,7 +126,7 @@ public class HilbertFunc extends VariationFunc {
 	  return size == 0;
 	}
 
-	// Checks if the given index is in range.  
+	// Checks if the given index is in range.
 	private void rangeCheck(int index)
 	{
 	  if (index >= size || index < 0)

--- a/src/org/jwildfire/create/tina/variation/HtreeFunc.java
+++ b/src/org/jwildfire/create/tina/variation/HtreeFunc.java
@@ -127,7 +127,7 @@ public class HtreeFunc extends VariationFunc {
 	  return size == 0;
 	}
 
-	// Checks if the given index is in range.  
+	// Checks if the given index is in range.
 	private void rangeCheck(int index)
 	{
 	  if (index >= size || index < 0)

--- a/src/org/jwildfire/create/tina/variation/KochFunc.java
+++ b/src/org/jwildfire/create/tina/variation/KochFunc.java
@@ -124,7 +124,7 @@ public class KochFunc extends VariationFunc {
 	  return size == 0;
 	}
 
-	// Checks if the given index is in range.  
+	// Checks if the given index is in range.
 	private void rangeCheck(int index)
 	{
 	  if (index >= size || index < 0)

--- a/src/org/jwildfire/create/tina/variation/LsystemFunc.java
+++ b/src/org/jwildfire/create/tina/variation/LsystemFunc.java
@@ -542,7 +542,7 @@ public class LsystemFunc extends VariationFunc {
       return size == 0;
     }
 
-    // Checks if the given index is in range.  
+    // Checks if the given index is in range.
     private void rangeCheck(int index) {
       if (index >= size || index < 0)
         throw new IndexOutOfBoundsException("Index: " + index + ", Size: " + size);

--- a/src/org/jwildfire/create/tina/variation/RsquaresFunc.java
+++ b/src/org/jwildfire/create/tina/variation/RsquaresFunc.java
@@ -127,7 +127,7 @@ public class RsquaresFunc extends VariationFunc {
 	  return size == 0;
 	}
 
-	// Checks if the given index is in range.  
+	// Checks if the given index is in range.
 	private void rangeCheck(int index)
 	{
 	  if (index >= size || index < 0)

--- a/src/org/jwildfire/create/tina/variation/TreeFunc.java
+++ b/src/org/jwildfire/create/tina/variation/TreeFunc.java
@@ -106,7 +106,7 @@ public class TreeFunc extends VariationFunc {
       return size == 0;
     }
 
-    // Checks if the given index is in range.  
+    // Checks if the given index is in range.
     private void rangeCheck(int index) {
       if (index >= size || index < 0)
         throw new IndexOutOfBoundsException("Index: " + index + ", Size: " + size);

--- a/src/org/jwildfire/create/tina/variation/mesh/LSystem3DWFFunc.java
+++ b/src/org/jwildfire/create/tina/variation/mesh/LSystem3DWFFunc.java
@@ -27,7 +27,7 @@
 * Check The work of Laurens Lapre
 * http://laurenslapre.nl/lapre_004.htm
 * 
-* Also I´m using SimpleMesh.java and AbstractOBJMeshWFFunc.java classes by Andreas Maschke 
+* Also I'm using SimpleMesh.java and AbstractOBJMeshWFFunc.java classes by Andreas Maschke 
 * included in source code of Java WildFire.
 *************************************************************************************************/
 
@@ -372,7 +372,7 @@ public class LSystem3DWFFunc extends AbstractOBJMeshWFFunc {
       return size == 0;
     }
 
-    // Checks if the given index is in range.  
+    // Checks if the given index is in range.
     private void rangeCheck(int index) {
       if (index >= size || index < 0)
         throw new IndexOutOfBoundsException("Index: " + index + ", Size: " + size);


### PR DESCRIPTION
…erscores and right-single-quote). Code itself is unchanged, as the only non-UTF-8 characters were in comments.

I am using NetBeans IDE on OSX, and non-UTF-8 characters in *.java files are throwing an error: "unmappable character for enoding UTF-8". Alternatively, I think this is probably fixable by fiddling with NetBeans file encoding settings. But my understanding is that keeping *.java files UTF-8 encoded is best to ensure maximum compatibility with compilers and IDEs. 