### PR TITLE
Make random gradients without fade colors use the right number of colors

### DIFF
--- a/src/org/jwildfire/create/tina/randomgradient/RandomGradientGenerator.java
+++ b/src/org/jwildfire/create/tina/randomgradient/RandomGradientGenerator.java
@@ -37,7 +37,7 @@ public abstract class RandomGradientGenerator {
       }
     }
     else {
-      double idxScl = (double) (RGBPalette.PALETTE_SIZE) / (double) (pKeyFrames.size() - 1);
+      double idxScl = (double) (RGBPalette.PALETTE_SIZE) / (double) (pKeyFrames.size() - (pFadeColors ? 1 : 0));
       for (int i = 0; i < RGBPalette.PALETTE_SIZE; i++) {
         double x = (double) i / idxScl;
         int lIdx = (int) x;


### PR DESCRIPTION
Fixes a bug: when fade colors was not checked, random gradients were
missing the last color.