### PR TITLE
Support for prepost variations, with prepost_affine and prepost_mobius

### DIFF
--- a/src/org/jwildfire/create/tina/base/XForm.java
+++ b/src/org/jwildfire/create/tina/base/XForm.java
@@ -428,8 +428,11 @@ public final class XForm implements Assignable<XForm>, Serializable {
     t.add(new TransformationPreparePreVariationsStep(this));
 
     for (Variation variation : variations) {
-      if (variation.getPriority() < 0) {
-        if (variation.getFunc().getPriority() < 0) {
+      if (variation.getPriority() < 0 || variation.getPriority() == 2) {
+        if (variation.getFunc().getPriority() == 2) {
+        	t.add(new PreInvVariationTransformationStep(this, variation));
+        }
+        else if (variation.getFunc().getPriority() < 0) {
           t.add(new PreVariationTransformationStep(this, variation));
         }
         else {
@@ -452,8 +455,11 @@ public final class XForm implements Assignable<XForm>, Serializable {
     }
 
     for (Variation variation : variations) {
-      if (variation.getPriority() > 0) {
-        if (variation.getFunc().getPriority() > 0) {
+      if (variation.getPriority() > 0 || variation.getPriority() == -2) {
+        if (variation.getFunc().getPriority() == -2) {
+          t.add(new PostInvVariationTransformationStep(this, variation));
+        }
+        else if (variation.getFunc().getPriority() > 0) {
           t.add(new PostVariationTransformationStep(this, variation));
         }
         else {

--- a/src/org/jwildfire/create/tina/swing/TinaController.java
+++ b/src/org/jwildfire/create/tina/swing/TinaController.java
@@ -2604,9 +2604,9 @@ public class TinaController implements FlameHolder, LayerHolder, ScriptRunnerEnv
       VariationFunc varFunc = pVar.getFunc();
 
       pRow.getNonlinearParamsPreButton().setEnabled(true);
-      pRow.getNonlinearParamsPreButton().setSelected(pVar.getPriority() < 0);
+      pRow.getNonlinearParamsPreButton().setSelected(pVar.getPriority() < 0 || pVar.getPriority() == 2);
       pRow.getNonlinearParamsPostButton().setEnabled(true);
-      pRow.getNonlinearParamsPostButton().setSelected(pVar.getPriority() > 0);
+      pRow.getNonlinearParamsPostButton().setSelected(pVar.getPriority() > 0 || pVar.getPriority() == -2);
       if (pRow.getNonlinearParamsUpButton() != null) {
         pRow.getNonlinearParamsUpButton().setEnabled(true);
       }
@@ -6431,11 +6431,29 @@ public class TinaController implements FlameHolder, LayerHolder, ScriptRunnerEnv
   }
 
   public void nonlinearParamsPreButtonClicked(int pIdx) {
-    nonlinearParamsPriorityChanged(pIdx, data.TinaNonlinearControlsRows[pIdx].getNonlinearParamsPreButton().isSelected() ? -1 : 0);
+	int fpriority;
+	XForm xForm = getCurrXForm();
+	if (xForm != null && pIdx < xForm.getVariationCount()) fpriority = xForm.getVariation(pIdx).getFunc().getPriority();
+	else fpriority = 0;
+	if ((fpriority == 2 || fpriority == -2) && data.TinaNonlinearControlsRows[pIdx].getNonlinearParamsPostButton().isSelected()) {
+	  nonlinearParamsPriorityChanged(pIdx, data.TinaNonlinearControlsRows[pIdx].getNonlinearParamsPreButton().isSelected() ? fpriority : 1);
+	}
+	else {
+      nonlinearParamsPriorityChanged(pIdx, data.TinaNonlinearControlsRows[pIdx].getNonlinearParamsPreButton().isSelected() ? -1 : 0);
+	}
   }
 
   public void nonlinearParamsPostButtonClicked(int pIdx) {
-    nonlinearParamsPriorityChanged(pIdx, data.TinaNonlinearControlsRows[pIdx].getNonlinearParamsPostButton().isSelected() ? 1 : 0);
+	int fpriority;
+	XForm xForm = getCurrXForm();
+	if (xForm != null && pIdx < xForm.getVariationCount()) fpriority = xForm.getVariation(pIdx).getFunc().getPriority();
+	else fpriority = 0;
+	if ((fpriority == 2 || fpriority == -2) && data.TinaNonlinearControlsRows[pIdx].getNonlinearParamsPreButton().isSelected()) {
+	  nonlinearParamsPriorityChanged(pIdx, data.TinaNonlinearControlsRows[pIdx].getNonlinearParamsPostButton().isSelected() ? fpriority : -1);
+	}
+	else {
+      nonlinearParamsPriorityChanged(pIdx, data.TinaNonlinearControlsRows[pIdx].getNonlinearParamsPostButton().isSelected() ? 1 : 0);
+	}
   }
 
   public void nonlinearParamsToggleParamsPnlClicked(int pIdx) {
@@ -6492,10 +6510,10 @@ public class TinaController implements FlameHolder, LayerHolder, ScriptRunnerEnv
         if (pIdx < xForm.getVariationCount()) {
           final Variation var = xForm.getVariation(pIdx);
           var.setPriority(pPriority);
-          if (pPriority >= 0) {
+          if (pPriority == 0 || pPriority == 1) {
             data.TinaNonlinearControlsRows[pIdx].getNonlinearParamsPreButton().setSelected(false);
           }
-          if (pPriority <= 0) {
+          if (pPriority == 0 || pPriority == -1) {
             data.TinaNonlinearControlsRows[pIdx].getNonlinearParamsPostButton().setSelected(false);
           }
           refreshFlameImage(true, false, 1, true, false);

--- a/src/org/jwildfire/create/tina/variation/CustomFullVariationWrapperFunc.java
+++ b/src/org/jwildfire/create/tina/variation/CustomFullVariationWrapperFunc.java
@@ -89,6 +89,13 @@ public class CustomFullVariationWrapperFunc extends VariationFunc {
   }
 
   @Override
+  public void invtransform(FlameTransformationContext pContext, XForm pXForm, XYZPoint pAffineTP, XYZPoint pVarTP, double pAmount) {
+    if (full_variation != null) {
+      full_variation.invtransform(pContext, pXForm, pAffineTP, pVarTP, pAmount);
+    }
+  }
+
+  @Override
   public String[] getParameterNames() {
     if (full_variation != null) {
       return full_variation.getParameterNames();

--- a/src/org/jwildfire/create/tina/variation/PrePostAffineFunc.java
+++ b/src/org/jwildfire/create/tina/variation/PrePostAffineFunc.java
@@ -1,0 +1,164 @@
+/*
+  JWildfire - an image and animation processor written in Java 
+  Copyright (C) 1995-2011 Andreas Maschke
+
+  This is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser 
+  General Public License as published by the Free Software Foundation; either version 2.1 of the 
+  License, or (at your option) any later version.
+ 
+  This software is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without 
+  even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU 
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License along with this software; 
+  if not, write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  02110-1301 USA, or see the FSF site: http://www.fsf.org.
+*/
+package org.jwildfire.create.tina.variation;
+
+import static org.jwildfire.base.mathlib.MathLib.M_PI;
+import static org.jwildfire.base.mathlib.MathLib.EPSILON;
+import static org.jwildfire.base.mathlib.MathLib.sin;
+import static org.jwildfire.base.mathlib.MathLib.cos;
+
+import org.jwildfire.create.tina.base.Layer;
+import org.jwildfire.create.tina.base.XForm;
+import org.jwildfire.create.tina.base.XYZPoint;
+
+public class PrePostAffineFunc extends VariationFunc {
+  private static final long serialVersionUID = 1L;
+
+  private static final String PARAM_SCALE_X = "scale_x";
+  private static final String PARAM_SCALE_Y = "scale_y";
+  private static final String PARAM_SCALE_Z = "scale_z";
+  private static final String PARAM_YAW = "yaw";
+  private static final String PARAM_PITCH = "pitch";
+  private static final String PARAM_ROLL = "roll";
+  private static final String PARAM_MOVE_X = "move_x";
+  private static final String PARAM_MOVE_Y = "move_y";
+  private static final String PARAM_MOVE_Z = "move_z";
+
+  private static final String[] paramNames = { PARAM_SCALE_X, PARAM_SCALE_Y, PARAM_SCALE_Z, PARAM_YAW, PARAM_PITCH, PARAM_ROLL, PARAM_MOVE_X, PARAM_MOVE_Y, PARAM_MOVE_Z };
+
+  private double scale_x = 1;
+  private double scale_y = 1;
+  private double scale_z = 1;
+  private double yaw = 0;
+  private double pitch = 0;
+  private double roll = 0;
+  private double move_x = 0;
+  private double move_y = 0;
+  private double move_z = 0;
+  
+  private double coefxx, coefxy, coefxz, coefyx, coefyy, coefyz, coefzx, coefzy, coefzz;
+  private double icoefxx, icoefxy, icoefxz, icoefyx, icoefyy, icoefyz, icoefzx, icoefzy, icoefzz;
+  
+
+  @Override
+  public void init(FlameTransformationContext pContext, Layer pLayer, XForm pXForm, double pAmount) {
+	// pre-calculate coefficients for transform
+	  double d2r = M_PI / 180;
+	  double sinyaw = sin(yaw * d2r), cosyaw = cos(yaw * d2r);
+	  double sinpitch = sin(pitch * d2r), cospitch = cos(pitch * d2r);
+	  double sinroll = sin(roll * d2r), cosroll = cos(roll * d2r);
+	  
+	  coefxx = cosyaw*cosroll - sinyaw*sinpitch*sinroll;
+	  coefxy = -sinyaw*cosroll - cosyaw*sinpitch*sinroll;
+	  coefxz = -cospitch*sinroll;
+	  
+	  coefyx = sinyaw*cospitch;
+	  coefyy = cosyaw*cospitch;
+	  coefyz = -sinpitch;
+	  
+	  coefzx = cosyaw*sinroll + sinyaw*sinpitch*cosroll;
+	  coefzy = cosyaw*sinpitch*cosroll - sinyaw*sinroll;
+	  coefzz = cospitch*cosroll;
+	  
+	  icoefxx = cosyaw*cosroll - sinyaw*sinpitch*sinroll;
+	  icoefxy = sinyaw*cospitch;
+	  icoefxz = cosyaw*sinroll + sinyaw*sinpitch*cosroll;
+	  
+	  icoefyx = -sinyaw*cosroll-cosyaw*sinpitch*sinroll;
+	  icoefyy = cosyaw*cospitch;
+	  icoefyz = cosyaw*sinpitch*cosroll - sinyaw*sinroll;
+	  
+	  icoefzx = -cospitch*sinroll;
+	  icoefzy = -sinpitch;
+	  icoefzz = cospitch*cosroll;
+  }
+
+  @Override
+  public void transform(FlameTransformationContext pContext, XForm pXForm, XYZPoint pAffineTP, XYZPoint pVarTP, double pAmount) {
+    // post affine, pVarTP -> pVarTP
+	  if (pAmount == 0) return;
+	  
+	  double x = pAmount * scale_x * pVarTP.x;
+	  double y = pAmount * scale_y * pVarTP.y;
+	  double z = pAmount * scale_z * pVarTP.z;
+	  
+	  pVarTP.x = coefxx*x + coefxy*y + coefxz*z + move_x;
+	  pVarTP.y = coefyx*x + coefyy*y + coefyz*z + move_y;
+	  pVarTP.z = coefzx*x + coefzy*y + coefzz*z + move_z;
+
+  }
+
+  @Override
+  public void invtransform(FlameTransformationContext pContext, XForm pXForm, XYZPoint pAffineTP, XYZPoint pVarTP, double pAmount) {
+    // pre affine, inverted, pAffineTP -> pAffineTP
+	  if (pAmount == 0) return;
+	  
+	  double x = pAffineTP.x - move_x;
+	  double y = pAffineTP.y - move_y;
+	  double z = pAffineTP.z - move_z;
+		  
+	  pAffineTP.x = (icoefxx*x + icoefxy*y + icoefxz*z) / (pAmount * scale_x);
+	  pAffineTP.y = (icoefyx*x + icoefyy*y + icoefyz*z) / (pAmount * scale_y);
+	  pAffineTP.z = (icoefzx*x + icoefzy*y + icoefzz*z) / (pAmount * scale_z);
+	  	  
+  }
+  
+  @Override
+  public String[] getParameterNames() {
+    return paramNames;
+  }
+
+  @Override
+  public Object[] getParameterValues() {
+    return new Object[] { scale_x, scale_y, scale_z, yaw, pitch, roll, move_x, move_y, move_z };
+  }
+
+  @Override
+  public void setParameter(String pName, double pValue) {
+    if (PARAM_SCALE_X.equalsIgnoreCase(pName))
+      scale_x = (pValue == 0) ? EPSILON : pValue;
+    else if (PARAM_SCALE_Y.equalsIgnoreCase(pName))
+      scale_y = (pValue == 0) ? EPSILON : pValue;
+    else if (PARAM_SCALE_Z.equalsIgnoreCase(pName))
+      scale_z = (pValue == 0) ? EPSILON : pValue;
+    else if (PARAM_YAW.equalsIgnoreCase(pName))
+      yaw = pValue;
+    else if (PARAM_PITCH.equalsIgnoreCase(pName))
+      pitch = pValue;
+    else if (PARAM_ROLL.equalsIgnoreCase(pName))
+      roll = pValue;
+    else if (PARAM_MOVE_X.equalsIgnoreCase(pName))
+      move_x = pValue;
+    else if (PARAM_MOVE_Y.equalsIgnoreCase(pName))
+      move_y = pValue;
+    else if (PARAM_MOVE_Z.equalsIgnoreCase(pName))
+      move_z = pValue;
+    else
+      throw new IllegalArgumentException(pName);
+  }
+
+  @Override
+  public String getName() {
+    return "prepost_affine";
+  }
+
+  @Override
+  public int getPriority() {
+    return 2;
+  }
+
+}

--- a/src/org/jwildfire/create/tina/variation/PrePostMobiusFunc.java
+++ b/src/org/jwildfire/create/tina/variation/PrePostMobiusFunc.java
@@ -1,0 +1,133 @@
+/*
+  JWildfire - an image and animation processor written in Java 
+  Copyright (C) 1995-2011 Andreas Maschke
+
+  This is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser 
+  General Public License as published by the Free Software Foundation; either version 2.1 of the 
+  License, or (at your option) any later version.
+ 
+  This software is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without 
+  even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU 
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License along with this software; 
+  if not, write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  02110-1301 USA, or see the FSF site: http://www.fsf.org.
+*/
+package org.jwildfire.create.tina.variation;
+
+import org.jwildfire.create.tina.base.XForm;
+import org.jwildfire.create.tina.base.XYZPoint;
+
+public class PrePostMobiusFunc extends VariationFunc {
+  private static final long serialVersionUID = 1L;
+
+  private static final String PARAM_RE_A = "re_a";
+  private static final String PARAM_RE_B = "re_b";
+  private static final String PARAM_RE_C = "re_c";
+  private static final String PARAM_RE_D = "re_d";
+  private static final String PARAM_IM_A = "im_a";
+  private static final String PARAM_IM_B = "im_b";
+  private static final String PARAM_IM_C = "im_c";
+  private static final String PARAM_IM_D = "im_d";
+
+  private static final String[] paramNames = { PARAM_RE_A, PARAM_RE_B, PARAM_RE_C, PARAM_RE_D, PARAM_IM_A, PARAM_IM_B, PARAM_IM_C, PARAM_IM_D };
+
+  private double re_a = 1;
+  private double re_b = 0;
+  private double re_c = 0;
+  private double re_d = 1;
+  private double im_a = 0;
+  private double im_b = 0;
+  private double im_c = 0;
+  private double im_d = 0;
+
+  @Override
+  public void transform(FlameTransformationContext pContext, XForm pXForm, XYZPoint pAffineTP, XYZPoint pVarTP, double pAmount) {
+    // post version of mobius
+	if (pAmount == 0) return;
+	
+    double re_u = re_a * pVarTP.x - im_a * pVarTP.y + re_b;
+    double im_u = re_a * pVarTP.y + im_a * pVarTP.x + im_b;
+    double re_v = re_c * pVarTP.x - im_c * pVarTP.y + re_d;
+    double im_v = re_c * pVarTP.y + im_c * pVarTP.x + im_d;
+
+    double d = (re_v * re_v + im_v * im_v);
+    if (d == 0) {
+      return;
+    }
+    double rad_v = pAmount / d;
+
+    pVarTP.x = rad_v * (re_u * re_v + im_u * im_v);
+    pVarTP.y = rad_v * (im_u * re_v - re_u * im_v);
+
+  }
+
+  @Override
+  public void invtransform(FlameTransformationContext pContext, XForm pXForm, XYZPoint pAffineTP, XYZPoint pVarTP, double pAmount) {
+    // pre version of mobius, inverted
+	if (pAmount == 0) return;
+	
+    double re_u = re_d * pAffineTP.x - im_d * pAffineTP.y - re_b;
+    double im_u = re_d * pAffineTP.y + im_d * pAffineTP.x - im_b;
+    double re_v = -re_c * pAffineTP.x + im_c * pAffineTP.y + re_a;
+    double im_v = -re_c * pAffineTP.y - im_c * pAffineTP.x + im_a;
+
+    double d = (re_v * re_v + im_v * im_v);
+    if (d == 0) {
+      return;
+    }
+    double rad_v = 1 / (pAmount * d);
+
+    pAffineTP.x = rad_v * (re_u * re_v + im_u * im_v);
+    pAffineTP.y = rad_v * (im_u * re_v - re_u * im_v);
+
+  }
+  @Override
+  public String[] getParameterNames() {
+    return paramNames;
+  }
+
+  @Override
+  public Object[] getParameterValues() {
+    return new Object[] { re_a, re_b, re_c, re_d, im_a, im_b, im_c, im_d };
+  }
+
+  @Override
+  public String[] getParameterAlternativeNames() {
+    return new String[] { "Re_A", "Re_B", "Re_C", "Re_D", "Im_A", "Im_B", "Im_C", "Im_D" };
+  }
+
+  @Override
+  public void setParameter(String pName, double pValue) {
+    if (PARAM_RE_A.equalsIgnoreCase(pName))
+      re_a = pValue;
+    else if (PARAM_RE_B.equalsIgnoreCase(pName))
+      re_b = pValue;
+    else if (PARAM_RE_C.equalsIgnoreCase(pName))
+      re_c = pValue;
+    else if (PARAM_RE_D.equalsIgnoreCase(pName))
+      re_d = pValue;
+    else if (PARAM_IM_A.equalsIgnoreCase(pName))
+      im_a = pValue;
+    else if (PARAM_IM_B.equalsIgnoreCase(pName))
+      im_b = pValue;
+    else if (PARAM_IM_C.equalsIgnoreCase(pName))
+      im_c = pValue;
+    else if (PARAM_IM_D.equalsIgnoreCase(pName))
+      im_d = pValue;
+    else
+      throw new IllegalArgumentException(pName);
+  }
+
+  @Override
+  public String getName() {
+    return "prepost_mobius";
+  }
+
+  @Override
+  public int getPriority() {
+    return 2;
+  }
+
+}

--- a/src/org/jwildfire/create/tina/variation/Variation.java
+++ b/src/org/jwildfire/create/tina/variation/Variation.java
@@ -73,6 +73,10 @@ public class Variation implements Assignable<Variation>, Serializable {
     func.transform(pContext, pXForm, pAffineTP, pVarTP, amount);
   }
 
+  public void invtransform(FlameTransformationContext pContext, XForm pXForm, XYZPoint pAffineTP, XYZPoint pVarTP) {
+    func.invtransform(pContext, pXForm, pAffineTP, pVarTP, amount);
+  }
+
   @Override
   public String toString() {
     return func.getName() + "(" + amount + ")";

--- a/src/org/jwildfire/create/tina/variation/VariationFunc.java
+++ b/src/org/jwildfire/create/tina/variation/VariationFunc.java
@@ -29,11 +29,24 @@ public abstract class VariationFunc implements Serializable {
 
   }
 
+  /**
+   * Specifies the type of variation:
+   *    0: normal
+   *   -1: pre
+   *    1: post
+   *   -2: prepost, with inverse post
+   *    2: prepost, with inverse pre
+   */
   public int getPriority() {
     return 0;
   }
 
   public abstract void transform(FlameTransformationContext pContext, XForm pXForm, XYZPoint pAffineTP, XYZPoint pVarTP, double pAmount);
+
+  // Only used by prepost transforms
+  public void invtransform(FlameTransformationContext pContext, XForm pXForm, XYZPoint pAffineTP, XYZPoint pVarTP, double pAmount) {
+	  
+  }
 
   public abstract String getName();
 

--- a/src/org/jwildfire/create/tina/variation/VariationFuncList.java
+++ b/src/org/jwildfire/create/tina/variation/VariationFuncList.java
@@ -599,6 +599,8 @@ public class VariationFuncList {
     registerVariationFunc(PreStabilizeFunc.class);
     registerVariationFunc(PreSphericalFunc.class);
     registerVariationFunc(PostSphericalFunc.class);
+    registerVariationFunc(PrePostMobiusFunc.class);
+    registerVariationFunc(PrePostAffineFunc.class);
 
     registerVariationFunc(InversionFunc.class);
     registerVariationFunc(KleinGroupFunc.class);
@@ -694,7 +696,8 @@ public class VariationFuncList {
     while (true) {
       int idx = (int) (Math.random() * getNameList().size());
       String name = getNameList().get(idx);
-      if (!(name.indexOf("inflate") == 0) && !name.equals("svg_wf") && !(name.indexOf("post_") == 0) && !(name.indexOf("pre_") == 0) && !name.equals("iflames_wf")) {
+      if (!(name.indexOf("inflate") == 0) && !name.equals("svg_wf") && !(name.indexOf("post_") == 0) && !(name.indexOf("pre_") == 0) 
+    		  	&& !(name.indexOf("prepost_") == 0) && !name.equals("iflames_wf")) {
         return name;
       }
     }


### PR DESCRIPTION
Prepost variations are executed both before the other variations (along
with other pre_ variations) and after the other variations (along with
other post_ variations). One of the two will be an inverse function,
calling invtransform instead of transform. Prepost variations are
identified with priority 2 (calls invtransform for pre and transform for
post) or -2 (calls transform for pre and invtransform for post).