### PR TITLE
Made Stereo3d SIDE_BY_SIDE_FULL preview use full preview area

### DIFF
--- a/src/org/jwildfire/create/tina/swing/flamepanel/FlamePanel.java
+++ b/src/org/jwildfire/create/tina/swing/flamepanel/FlamePanel.java
@@ -36,6 +36,8 @@ import org.jwildfire.base.Tools;
 import org.jwildfire.base.mathlib.MathLib;
 import org.jwildfire.create.tina.base.Flame;
 import org.jwildfire.create.tina.base.Layer;
+import org.jwildfire.create.tina.base.Stereo3dMode;
+import org.jwildfire.create.tina.base.Stereo3dPreview;
 import org.jwildfire.create.tina.base.XForm;
 import org.jwildfire.create.tina.base.XYZPoint;
 import org.jwildfire.create.tina.random.RandomGeneratorFactory;
@@ -196,6 +198,10 @@ public class FlamePanel extends ImagePanel {
 
   public Rectangle getImageBounds() {
     Rectangle bounds = this.getBounds();
+    if (!config.isProgressivePreview() && flameHolder.getFlame() != null && flameHolder.getFlame().getStereo3dMode() != Stereo3dMode.NONE && 
+    		flameHolder.getFlame().getStereo3dPreview() == Stereo3dPreview.SIDE_BY_SIDE_FULL) {
+    	return bounds;   	
+    }
     double aspect = (double) bounds.width / (double) bounds.height;
     int imageWidth, imageHeight;
     if (aspect <= renderAspect) {
@@ -211,6 +217,10 @@ public class FlamePanel extends ImagePanel {
 
   public Rectangle getParentImageBounds() {
     Rectangle bounds = this.getParent().getBounds();
+    if (!config.isProgressivePreview() && flameHolder.getFlame() != null && flameHolder.getFlame().getStereo3dMode() != Stereo3dMode.NONE && 
+    		flameHolder.getFlame().getStereo3dPreview() == Stereo3dPreview.SIDE_BY_SIDE_FULL) {
+    	return bounds;   	
+    }
     double aspect = (double) bounds.width / (double) bounds.height;
     int imageWidth, imageHeight;
     if (aspect <= renderAspect) {


### PR DESCRIPTION
It isn't clear just what SIDE_BY_SIDE_FULL is supposed to do, but it
doesn't do anything in v3.30. After trying several options, I think
making it use the entire preview area (ignoring the resolution profile)
works best.