### PR TITLE
Bug fix: gradient reset button breaks range editing

### DIFF
--- a/src/org/jwildfire/create/tina/swing/TinaController.java
+++ b/src/org/jwildfire/create/tina/swing/TinaController.java
@@ -6210,6 +6210,7 @@ public class TinaController implements FlameHolder, LayerHolder, ScriptRunnerEnv
     if (getLastGradient() != null && getCurrLayer() != null) {
       saveUndoPoint();
       getCurrLayer().setPalette(getLastGradient().makeDeepCopy());
+      registerToEditor(getCurrFlame(), getCurrLayer());
       refreshUI();
     }
   }


### PR DESCRIPTION
Clicking the button to reset the gradient to the initial state broke the
range selection so the Fade, Invert, etc. buttons affected the entire
gradient instead of the selected range. Fixed by re-registering the
current flame and layer to the editor.