### PR TITLE
update (build.xml) include quickhull3d.1.4.jar and megamu.mesh package

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -68,6 +68,8 @@
       <fileset dir="${build.dir}" includes="com/"/>
       <fileset dir="${build.dir}" includes="odk/"/>
       <fileset dir="${build.dir}" includes="net/goui/"/>
+      <fileset dir="${build.dir}" includes="megamu/"/>
+      <zipfileset src="lib/quickhull3d.1.4.jar"/>		
       <zipfileset src="lib/jep-2.4.1.jar"/>
       <zipfileset src="lib/sunflow.jar"/>
       <zipfileset src="lib/janino.jar"/>


### PR DESCRIPTION
the variation sunvoroni is not working because needs quickhull3d.1.4.jar
& megamu.mesh package