### PR TITLE
Bug fix: Render Fractal was sometimes dimmer than Interactive Render

### DIFF
--- a/src/org/jwildfire/create/tina/render/FlameRenderer.java
+++ b/src/org/jwildfire/create/tina/render/FlameRenderer.java
@@ -715,7 +715,7 @@ public class FlameRenderer {
   }
 
   private void iterate(int pPart, int pParts, List<List<RenderPacket>> pPackets, List<RenderSlice> pSlices) {
-    long nSamples = (long) ((flame.getSampleDensity() * (double) rasterSize / (double) flame.calcPostSymmetrySampleMultiplier() / (double) flame.calcStereo3dSampleMultiplier() / (double) (oversample) + 0.5));
+    long nSamples = (long) ((flame.getSampleDensity() * (double) rasterSize /  (double) flame.calcStereo3dSampleMultiplier() / (double) (oversample) + 0.5));
     int PROGRESS_STEPS = 21;
     if (progressUpdater != null && pPart == 0) {
       progressChangePerPhase = (PROGRESS_STEPS - 1) * pParts;


### PR DESCRIPTION
When Post symmetry is enabled, the result of clicking Render was dimmer
than using Interactive Render, especially with large Symmetry order
values. This change makes Render Fractal and Interactive Render produce
the same results when Post symmetry is enabled.