### PR TITLE
Coloring changes

### DIFF
--- a/src/org/jwildfire/create/tina/animate/FlameMorphService.java
+++ b/src/org/jwildfire/create/tina/animate/FlameMorphService.java
@@ -283,6 +283,7 @@ public class FlameMorphService {
 
     res.setOpacity(morphValue(pXForm1.getOpacity(), pXForm2.getOpacity(), pFScl));
     res.setDrawMode(pFScl >= 0.5 ? pXForm2.getDrawMode() : pXForm1.getDrawMode());
+    res.setColorType(pFScl >= 0.5 ? pXForm2.getColorType() : pXForm1.getColorType());
     for (int i = 0; i < pXForm1.getModifiedWeights().length; i++) {
       res.getModifiedWeights()[i] = morphValue(pXForm1.getModifiedWeights()[i], pXForm2.getModifiedWeights()[i], pFScl);
     }

--- a/src/org/jwildfire/create/tina/base/ColorType.java
+++ b/src/org/jwildfire/create/tina/base/ColorType.java
@@ -1,0 +1,21 @@
+/*
+  JWildfire - an image and animation processor written in Java 
+  Copyright (C) 1995-2012 Andreas Maschke
+
+  This is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser 
+  General Public License as published by the Free Software Foundation; either version 2.1 of the 
+  License, or (at your option) any later version.
+ 
+  This software is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without 
+  even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU 
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License along with this software; 
+  if not, write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  02110-1301 USA, or see the FSF site: http://www.fsf.org.
+*/
+package org.jwildfire.create.tina.base;
+
+public enum ColorType {
+  NONE, DIFFUSION
+}

--- a/src/org/jwildfire/create/tina/base/ColorType.java
+++ b/src/org/jwildfire/create/tina/base/ColorType.java
@@ -17,5 +17,5 @@
 package org.jwildfire.create.tina.base;
 
 public enum ColorType {
-  NONE, DIFFUSION
+  UNSET, NONE, DIFFUSION
 }

--- a/src/org/jwildfire/create/tina/base/Layer.java
+++ b/src/org/jwildfire/create/tina/base/Layer.java
@@ -124,6 +124,7 @@ public class Layer implements Assignable<Layer>, Serializable {
     int n = getXForms().size();
     {
       for (XForm xForm : this.getXForms()) {
+        if (xForm.getColorType() == ColorType.UNSET) xForm.setColorType(ColorType.DIFFUSION);
         xForm.initTransform();
         if(pFlameTransformationContext.getThreadId()==0) {
           for (Variation var : xForm.getVariations()) {
@@ -137,6 +138,7 @@ public class Layer implements Assignable<Layer>, Serializable {
     }
     {
       for (XForm xForm : this.getFinalXForms()) {
+        if (xForm.getColorType() == ColorType.UNSET) xForm.setColorType(ColorType.NONE);
         xForm.initTransform();
         if(pFlameTransformationContext.getThreadId()==0) {
           for (Variation var : xForm.getVariations()) {

--- a/src/org/jwildfire/create/tina/base/Layer.java
+++ b/src/org/jwildfire/create/tina/base/Layer.java
@@ -18,6 +18,9 @@ package org.jwildfire.create.tina.base;
 
 import static org.jwildfire.base.mathlib.MathLib.EPSILON;
 import static org.jwildfire.base.mathlib.MathLib.fabs;
+import org.jwildfire.image.SimpleImage;
+import org.jwildfire.create.GradientCreator;
+import org.jwildfire.create.tina.variation.RessourceManager;
 
 import java.io.Serializable;
 import java.util.List;
@@ -25,6 +28,7 @@ import java.util.List;
 import org.jwildfire.create.tina.animate.AnimAware;
 import org.jwildfire.create.tina.edit.Assignable;
 import org.jwildfire.create.tina.palette.RGBPalette;
+import org.jwildfire.create.tina.palette.RenderColor;
 import org.jwildfire.create.tina.variation.FlameTransformationContext;
 import org.jwildfire.create.tina.variation.Variation;
 
@@ -54,6 +58,8 @@ public class Layer implements Assignable<Layer>, Serializable {
   private double gradientMapLocalColorAdd = 0.8;
   private double gradientMapLocalColorScale = 0.2;
   private boolean smoothGradient = false;
+  private RenderColor[] colorMap = null;
+  private SimpleImage gradientMap = null;
 
   public List<XForm> getXForms() {
     return xForms;
@@ -71,6 +77,14 @@ public class Layer implements Assignable<Layer>, Serializable {
     if (pPalette == null || pPalette.getSize() != RGBPalette.PALETTE_SIZE)
       throw new IllegalArgumentException(pPalette != null ? pPalette.toString() + " " + pPalette.getSize() : "NULL");
     palette = pPalette;
+    colorMap = null;
+  }
+  
+  public RenderColor[] getColorMap() {
+    if (colorMap == null) {
+      colorMap = palette.createRenderPalette(owner.getWhiteLevel());
+    }
+    return colorMap;
   }
 
   public void distributeColors() {
@@ -254,6 +268,7 @@ public class Layer implements Assignable<Layer>, Serializable {
 
   public void setGradientMapFilename(String gradientMapFilename) {
     this.gradientMapFilename = gradientMapFilename != null ? gradientMapFilename : "";
+    this.gradientMap = null;
   }
 
   public void setOwner(Flame pOwner) {
@@ -318,6 +333,27 @@ public class Layer implements Assignable<Layer>, Serializable {
 
   public void setGradientMapLocalColorScale(double pGradientMapLocalColorScale) {
     gradientMapLocalColorScale = pGradientMapLocalColorScale;
+  }
+  
+  public boolean isGradientMap() {
+    return this.gradientMapFilename != null && this.gradientMapFilename.length() > 0;
+  }
+  
+  private SimpleImage createDfltImage() {
+    GradientCreator creator = new GradientCreator();
+    return creator.createImage(256, 256);
+  }
+  public SimpleImage getGradientMap() {
+    if (gradientMap == null && isGradientMap()) {
+      try {
+        gradientMap = (SimpleImage) RessourceManager.getImage(this.gradientMapFilename);
+      }
+      catch (Exception e) {
+        e.printStackTrace();
+        gradientMap = createDfltImage();
+      }
+    }
+    return gradientMap;
   }
 
 }

--- a/src/org/jwildfire/create/tina/base/TransformationGradientColorStep.java
+++ b/src/org/jwildfire/create/tina/base/TransformationGradientColorStep.java
@@ -16,29 +16,37 @@
 */
 package org.jwildfire.create.tina.base;
 
+import org.jwildfire.create.tina.palette.RenderColor;
+import org.jwildfire.create.tina.palette.RGBPalette;
 import org.jwildfire.create.tina.variation.FlameTransformationContext;
 
-public final class TransformationInitStep extends AbstractTransformationStep {
+public final class TransformationGradientColorStep extends AbstractTransformationStep {
   private static final long serialVersionUID = 1L;
 
-  public TransformationInitStep(XForm pXForm) {
+  public TransformationGradientColorStep(XForm pXForm) {
     super(pXForm);
   }
 
   @Override
   public void transform(FlameTransformationContext pContext, XYZPoint pAffineT, XYZPoint pVarT, XYZPoint pSrcPoint, XYZPoint pDstPoint) {
-    pAffineT.clear();
-    pAffineT.doHide = pSrcPoint.doHide;
-    pAffineT.receiveOnlyShadows = false;
-    pAffineT.color = pSrcPoint.color * xform.c1 + xform.c2;
-    pAffineT.rgbColor = false;  // used to detect variations that use true color
-    pAffineT.redColor = pSrcPoint.redColor;
-    pAffineT.greenColor = pSrcPoint.greenColor;
-    pAffineT.blueColor = pSrcPoint.blueColor;
-    pAffineT.material = pSrcPoint.material * xform.material1 + xform.material2;
-    pAffineT.modGamma = pSrcPoint.modGamma * xform.modGamma1 + xform.modGamma2;
-    pAffineT.modContrast = pSrcPoint.modContrast * xform.modContrast1 + xform.modContrast2;
-    pAffineT.modSaturation = pSrcPoint.modSaturation * xform.modSaturation1 + xform.modSaturation2;
-    pAffineT.modHue = pSrcPoint.modHue * xform.modHue1 + xform.modHue2;
+    
+    if (pDstPoint.rgbColor) {  
+      return;
+    }
+    
+    RenderColor[] colorMap = xform.getOwner().getColorMap();
+    double paletteIdxScl = colorMap.length - 2;
+    int colorIdx = (int) (pDstPoint.color * paletteIdxScl + 0.5);
+    if (colorIdx < 0)
+      colorIdx = 0;
+    else if (colorIdx >= RGBPalette.PALETTE_SIZE)
+      colorIdx = RGBPalette.PALETTE_SIZE - 1;
+    
+    RenderColor color = colorMap[colorIdx];
+    pDstPoint.redColor = color.red;
+    pDstPoint.greenColor = color.green;
+    pDstPoint.blueColor = color.blue;
+
   }
+
 }

--- a/src/org/jwildfire/create/tina/base/TransformationGradientMapColorStep.java
+++ b/src/org/jwildfire/create/tina/base/TransformationGradientMapColorStep.java
@@ -1,0 +1,90 @@
+/*
+  JWildfire - an image and animation processor written in Java 
+  Copyright (C) 1995-2014 Andreas Maschke
+
+  This is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser 
+  General Public License as published by the Free Software Foundation; either version 2.1 of the 
+  License, or (at your option) any later version.
+ 
+  This software is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without 
+  even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU 
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License along with this software; 
+  if not, write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  02110-1301 USA, or see the FSF site: http://www.fsf.org.
+*/
+package org.jwildfire.create.tina.base;
+
+import org.jwildfire.base.mathlib.GfxMathLib;
+import org.jwildfire.base.mathlib.MathLib;
+import org.jwildfire.image.Pixel;
+import org.jwildfire.image.SimpleImage;
+
+
+import org.jwildfire.create.tina.variation.FlameTransformationContext;
+
+public final class TransformationGradientMapColorStep extends AbstractTransformationStep {
+  private static final long serialVersionUID = 1L;
+
+  public TransformationGradientMapColorStep(XForm pXForm) {
+    super(pXForm);
+  }
+
+  private final Pixel toolPixel = new Pixel();
+
+  @Override
+  public void transform(FlameTransformationContext pContext, XYZPoint pAffineT, XYZPoint pVarT, XYZPoint pSrcPoint, XYZPoint pDstPoint) {
+    
+    if (pDstPoint.rgbColor) {  
+      return;
+    }
+    
+    SimpleImage map = xform.getOwner().getGradientMap();
+
+    double localColorAdd = xform.getOwner().getGradientMapLocalColorAdd();
+    double localColorMultiply = xform.getOwner().getGradientMapLocalColorScale();
+
+    double x = (pDstPoint.x * (1.0 - localColorMultiply) + pDstPoint.x * localColorMultiply * pDstPoint.color + localColorAdd * pDstPoint.color) * xform.getOwner().getGradientMapHorizScale() + xform.getOwner().getGradientMapHorizOffset();
+    double y = (pDstPoint.y * (1.0 - localColorMultiply) + pDstPoint.y * localColorMultiply * pDstPoint.color + localColorAdd * pDstPoint.color) * xform.getOwner().getGradientMapVertScale() + xform.getOwner().getGradientMapVertOffset();
+
+    double width = map.getImageWidth() - 2;
+    double height = map.getImageHeight() - 2;
+    double fx = MathLib.fabs(x);
+    double imageX = MathLib.fmod(fx * width, width);
+    if (((int) fx) % 2 != 0) {
+      imageX = width - imageX;
+    }
+    double fy = MathLib.fabs(y);
+    double imageY = MathLib.fmod(fy * height, height);
+    if (((int) fy) % 2 != 0) {
+      imageY = height - imageY;
+    }
+
+    toolPixel.setARGBValue(map.getARGBValueIgnoreBounds((int) imageX, (int) imageY));
+    int luR = toolPixel.r;
+    int luG = toolPixel.g;
+    int luB = toolPixel.b;
+
+    toolPixel.setARGBValue(map.getARGBValueIgnoreBounds(((int) imageX) + 1, (int) imageY));
+    int ruR = toolPixel.r;
+    int ruG = toolPixel.g;
+    int ruB = toolPixel.b;
+    toolPixel.setARGBValue(map.getARGBValueIgnoreBounds((int) imageX, ((int) imageY) + 1));
+    int lbR = toolPixel.r;
+    int lbG = toolPixel.g;
+    int lbB = toolPixel.b;
+    toolPixel.setARGBValue(map.getARGBValueIgnoreBounds(((int) imageX) + 1, ((int) imageY) + 1));
+    int rbR = toolPixel.r;
+    int rbG = toolPixel.g;
+    int rbB = toolPixel.b;
+
+    double localX = MathLib.frac(imageX);
+    double localY = MathLib.frac(imageY);
+    pDstPoint.redColor = GfxMathLib.blerp(luR, ruR, lbR, rbR, localX, localY);
+    pDstPoint.greenColor = GfxMathLib.blerp(luG, ruG, lbG, rbG, localX, localY);
+    pDstPoint.blueColor = GfxMathLib.blerp(luB, ruB, lbB, rbB, localX, localY);
+
+  }
+
+}

--- a/src/org/jwildfire/create/tina/base/TransformationSmoothGradientColorStep.java
+++ b/src/org/jwildfire/create/tina/base/TransformationSmoothGradientColorStep.java
@@ -1,0 +1,71 @@
+/*
+  JWildfire - an image and animation processor written in Java 
+  Copyright (C) 1995-2014 Andreas Maschke
+
+  This is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser 
+  General Public License as published by the Free Software Foundation; either version 2.1 of the 
+  License, or (at your option) any later version.
+ 
+  This software is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without 
+  even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU 
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License along with this software; 
+  if not, write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  02110-1301 USA, or see the FSF site: http://www.fsf.org.
+*/
+package org.jwildfire.create.tina.base;
+
+import org.jwildfire.create.tina.palette.RenderColor;
+import org.jwildfire.create.tina.palette.RGBPalette;
+import org.jwildfire.base.mathlib.GfxMathLib;
+import org.jwildfire.base.mathlib.MathLib;
+import org.jwildfire.create.tina.variation.FlameTransformationContext;
+
+public final class TransformationSmoothGradientColorStep extends AbstractTransformationStep {
+  private static final long serialVersionUID = 1L;
+
+  public TransformationSmoothGradientColorStep(XForm pXForm) {
+    super(pXForm);
+  }
+
+  @Override
+  public void transform(FlameTransformationContext pContext, XYZPoint pAffineT, XYZPoint pVarT, XYZPoint pSrcPoint, XYZPoint pDstPoint) {
+    
+    if (pDstPoint.rgbColor) {  
+      return;
+    }
+    
+    RenderColor[] colorMap = xform.getOwner().getColorMap();
+    double paletteIdxScl = colorMap.length - 2;
+    double colorIdx = pDstPoint.color * paletteIdxScl;
+    int lIdx = (int) colorIdx;
+    double lR, lG, lB;
+    if (lIdx >= 0 && lIdx < RGBPalette.PALETTE_SIZE) {
+      lR = colorMap[lIdx].red;
+      lG = colorMap[lIdx].green;
+      lB = colorMap[lIdx].blue;
+    }
+    else {
+      lR = lG = lB = 0.0;
+    }
+
+    double rR, rG, rB;
+    int rIdx = lIdx + 1;
+    if (rIdx >= 0 && rIdx < RGBPalette.PALETTE_SIZE) {
+      rR = colorMap[rIdx].red;
+      rG = colorMap[rIdx].green;
+      rB = colorMap[rIdx].blue;
+    }
+    else {
+      rR = rG = rB = 0.0;
+    }
+
+    double t = MathLib.frac(colorIdx);
+    pDstPoint.redColor = GfxMathLib.lerp(lR, rR, t);
+    pDstPoint.greenColor = GfxMathLib.lerp(lG, rG, t);
+    pDstPoint.blueColor = GfxMathLib.lerp(lB, rB, t);
+
+  }
+
+}

--- a/src/org/jwildfire/create/tina/base/XForm.java
+++ b/src/org/jwildfire/create/tina/base/XForm.java
@@ -203,7 +203,7 @@ public final class XForm implements Assignable<XForm>, Serializable {
   private final MotionCurve opacityCurve = new MotionCurve();
   private final XForm[] nextAppliedXFormTable = new XForm[Constants.NEXT_APPLIED_XFORM_TABLE_SIZE];
   private DrawMode drawMode = DrawMode.NORMAL;
-  private ColorType colorType = ColorType.DIFFUSION;
+  private ColorType colorType = ColorType.UNSET;
   private String name = "";
 
   private final MotionCurve xyRotateCurve = new MotionCurve(RotateMotionValueChangeHandler.INSTANCE);
@@ -332,7 +332,7 @@ public final class XForm implements Assignable<XForm>, Serializable {
     //   pDstPoint.color = pSrcPoint.color * c1 + c2;
     c1 = (1 + colorSymmetry) * 0.5;
     c2 = color * (1 - colorSymmetry) * 0.5;
-    if (colorType == ColorType.NONE) {
+    if (colorType != ColorType.DIFFUSION) {
       c1 = 1;
       c2 = 0;
     }

--- a/src/org/jwildfire/create/tina/base/XForm.java
+++ b/src/org/jwildfire/create/tina/base/XForm.java
@@ -203,6 +203,7 @@ public final class XForm implements Assignable<XForm>, Serializable {
   private final MotionCurve opacityCurve = new MotionCurve();
   private final XForm[] nextAppliedXFormTable = new XForm[Constants.NEXT_APPLIED_XFORM_TABLE_SIZE];
   private DrawMode drawMode = DrawMode.NORMAL;
+  private ColorType colorType = ColorType.DIFFUSION;
   private String name = "";
 
   private final MotionCurve xyRotateCurve = new MotionCurve(RotateMotionValueChangeHandler.INSTANCE);
@@ -331,6 +332,10 @@ public final class XForm implements Assignable<XForm>, Serializable {
     //   pDstPoint.color = pSrcPoint.color * c1 + c2;
     c1 = (1 + colorSymmetry) * 0.5;
     c2 = color * (1 - colorSymmetry) * 0.5;
+    if (colorType == ColorType.NONE) {
+      c1 = 1;
+      c2 = 0;
+    }
 
     material1 = (1 + materialSpeed) * 0.5;
     material2 = material * (1 - materialSpeed) * 0.5;
@@ -478,6 +483,18 @@ public final class XForm implements Assignable<XForm>, Serializable {
     else {
       t.add(new TransformationPostAffineStep(this));
     }
+    
+    if (colorType == ColorType.DIFFUSION) {
+      if (owner.isGradientMap()) {
+        t.add(new TransformationGradientMapColorStep(this));
+      }
+      else if (owner.isSmoothGradient()) {
+        t.add(new TransformationSmoothGradientColorStep(this));
+      }
+      else {
+        t.add(new TransformationGradientColorStep(this));
+      }
+    }
   }
 
   public void transformPoint(FlameTransformationContext pContext, XYZPoint pAffineT, XYZPoint pVarT, XYZPoint pSrcPoint, XYZPoint pDstPoint) {
@@ -508,6 +525,14 @@ public final class XForm implements Assignable<XForm>, Serializable {
 
   public void setDrawMode(DrawMode drawMode) {
     this.drawMode = drawMode;
+  }
+  
+  public ColorType getColorType() {
+    return colorType;
+  }
+
+  public void setColorType(ColorType colorType) {
+    this.colorType = colorType;
   }
   
   @Override
@@ -638,6 +663,7 @@ public final class XForm implements Assignable<XForm>, Serializable {
     opacity = pXForm.opacity;
     opacityCurve.assign(pXForm.opacityCurve);
     drawMode = pXForm.drawMode;
+    colorType = pXForm.colorType;
     name = pXForm.name;
   }
 
@@ -709,6 +735,8 @@ public final class XForm implements Assignable<XForm>, Serializable {
         (fabs(opacity - pSrc.opacity) > EPSILON) || !opacityCurve.isEqual(pSrc.opacityCurve) ||
         ((drawMode != null && pSrc.drawMode == null) || (drawMode == null && pSrc.drawMode != null) ||
         (drawMode != null && pSrc.drawMode != null && !drawMode.equals(pSrc.drawMode))) ||
+        ((colorType != null && pSrc.colorType == null) || (colorType == null && pSrc.colorType != null) ||
+        (colorType != null && pSrc.colorType != null && !colorType.equals(pSrc.colorType))) ||
         !name.equals(pSrc.name) ||
         (modifiedWeights.length != pSrc.modifiedWeights.length) || (variations.size() != pSrc.variations.size())) {
       return false;

--- a/src/org/jwildfire/create/tina/io/AbstractFlameReader.java
+++ b/src/org/jwildfire/create/tina/io/AbstractFlameReader.java
@@ -28,6 +28,7 @@ import org.jwildfire.create.tina.animate.AnimationService;
 import org.jwildfire.create.tina.animate.AnimationService.MotionCurveAttribute;
 import org.jwildfire.create.tina.base.BGColorType;
 import org.jwildfire.create.tina.base.DrawMode;
+import org.jwildfire.create.tina.base.ColorType;
 import org.jwildfire.create.tina.base.Flame;
 import org.jwildfire.create.tina.base.Layer;
 import org.jwildfire.create.tina.base.PostSymmetryType;
@@ -856,6 +857,7 @@ public class AbstractFlameReader {
   }
 
   public static final String ATTR_WEIGHT = "weight";
+  public static final String ATTR_COLOR_TYPE = "color_type";
   public static final String ATTR_COLOR = "color";
   public static final String ATTR_OPACITY = "opacity";
   public static final String ATTR_XY_COEFS = "coefs";
@@ -910,6 +912,14 @@ public class AbstractFlameReader {
     if ((hs = atts.get(ATTR_MIRROR_PRE_POST_TRANSLATIONS)) != null) {
       double val = Double.parseDouble(hs);
       pXForm.setMirrorTranslations(val == 1);
+    }
+    if ((hs = atts.get(ATTR_COLOR_TYPE)) != null) {
+      try {
+        pXForm.setColorType(ColorType.valueOf(hs));
+      }
+      catch (Exception ex) {
+        ex.printStackTrace();
+      }
     }
     if ((hs = atts.get(ATTR_COLOR)) != null) {
       pXForm.setColor(Double.parseDouble(hs));

--- a/src/org/jwildfire/create/tina/io/AbstractFlameWriter.java
+++ b/src/org/jwildfire/create/tina/io/AbstractFlameWriter.java
@@ -54,6 +54,7 @@ import org.jwildfire.create.tina.animate.AnimationService;
 import org.jwildfire.create.tina.animate.AnimationService.MotionCurveAttribute;
 import org.jwildfire.create.tina.base.BGColorType;
 import org.jwildfire.create.tina.base.DrawMode;
+import org.jwildfire.create.tina.base.ColorType;
 import org.jwildfire.create.tina.base.Flame;
 import org.jwildfire.create.tina.base.Layer;
 import org.jwildfire.create.tina.base.Stereo3dMode;
@@ -72,6 +73,7 @@ public class AbstractFlameWriter {
   protected List<SimpleXMLBuilder.Attribute<?>> createXFormAttrList(SimpleXMLBuilder pXB, Layer pLayer, XForm pXForm) throws Exception {
     List<SimpleXMLBuilder.Attribute<?>> attrList = new ArrayList<SimpleXMLBuilder.Attribute<?>>();
     attrList.add(pXB.createAttr("weight", pXForm.getWeight()));
+    attrList.add(pXB.createAttr(AbstractFlameReader.ATTR_COLOR_TYPE, pXForm.getColorType().toString()));
     attrList.add(pXB.createAttr("color", pXForm.getColor()));
     attrList.add(pXB.createAttr("symmetry", pXForm.getColorSymmetry()));
     attrList.add(pXB.createAttr(AbstractFlameReader.ATTR_MIRROR_PRE_POST_TRANSLATIONS, pXForm.getMirrorTranslations() ? 1 : 0));

--- a/src/org/jwildfire/create/tina/io/AbstractFlameWriter.java
+++ b/src/org/jwildfire/create/tina/io/AbstractFlameWriter.java
@@ -73,7 +73,7 @@ public class AbstractFlameWriter {
   protected List<SimpleXMLBuilder.Attribute<?>> createXFormAttrList(SimpleXMLBuilder pXB, Layer pLayer, XForm pXForm) throws Exception {
     List<SimpleXMLBuilder.Attribute<?>> attrList = new ArrayList<SimpleXMLBuilder.Attribute<?>>();
     attrList.add(pXB.createAttr("weight", pXForm.getWeight()));
-    attrList.add(pXB.createAttr(AbstractFlameReader.ATTR_COLOR_TYPE, pXForm.getColorType().toString()));
+    if (pXForm.getColorType() != ColorType.UNSET) attrList.add(pXB.createAttr(AbstractFlameReader.ATTR_COLOR_TYPE, pXForm.getColorType().toString()));
     attrList.add(pXB.createAttr("color", pXForm.getColor()));
     attrList.add(pXB.createAttr("symmetry", pXForm.getColorSymmetry()));
     attrList.add(pXB.createAttr(AbstractFlameReader.ATTR_MIRROR_PRE_POST_TRANSLATIONS, pXForm.getMirrorTranslations() ? 1 : 0));

--- a/src/org/jwildfire/create/tina/render/DefaultRenderIterationState.java
+++ b/src/org/jwildfire/create/tina/render/DefaultRenderIterationState.java
@@ -26,13 +26,10 @@ import static org.jwildfire.base.mathlib.MathLib.log;
 import static org.jwildfire.base.mathlib.MathLib.sin;
 import static org.jwildfire.base.mathlib.MathLib.sqrt;
 
-import java.io.Serializable;
 import java.util.List;
 
 import org.jwildfire.base.Tools;
-import org.jwildfire.base.mathlib.GfxMathLib;
 import org.jwildfire.base.mathlib.MathLib;
-import org.jwildfire.create.GradientCreator;
 import org.jwildfire.create.tina.base.Constants;
 import org.jwildfire.create.tina.base.DrawMode;
 import org.jwildfire.create.tina.base.Flame;
@@ -41,14 +38,9 @@ import org.jwildfire.create.tina.base.XForm;
 import org.jwildfire.create.tina.base.XYZPoint;
 import org.jwildfire.create.tina.base.XYZProjectedPoint;
 import org.jwildfire.create.tina.base.solidrender.ShadowType;
-import org.jwildfire.create.tina.palette.RGBPalette;
-import org.jwildfire.create.tina.palette.RenderColor;
 import org.jwildfire.create.tina.random.AbstractRandomGenerator;
 import org.jwildfire.create.tina.render.GammaCorrectionFilter.HSLRGBConverter;
 import org.jwildfire.create.tina.variation.FlameTransformationContext;
-import org.jwildfire.create.tina.variation.RessourceManager;
-import org.jwildfire.image.Pixel;
-import org.jwildfire.image.SimpleImage;
 
 public class DefaultRenderIterationState extends RenderIterationState {
 
@@ -61,7 +53,6 @@ public class DefaultRenderIterationState extends RenderIterationState {
   protected XForm xf;
   protected final XYZProjectedPoint prj;
   protected PointProjector projector;
-  protected final ColorProvider colorProvider;
   protected final boolean solidRendering;
 
   public DefaultRenderIterationState(AbstractRenderThread pRenderThread, FlameRenderer pRenderer, RenderPacket pPacket, Layer pLayer, FlameTransformationContext pCtx, AbstractRandomGenerator pRandGen, boolean pUsePlotBuffer) {
@@ -69,12 +60,6 @@ public class DefaultRenderIterationState extends RenderIterationState {
     plotBuffer = initPlotBuffer(pUsePlotBuffer ? (RenderMode.PRODUCTION.equals(pRenderer.getRenderInfo().getRenderMode()) ? Tools.PLOT_BUFFER_SIZE : Tools.PLOT_BUFFER_SIZE / 2) : 1);
     solidRendering = flame.getSolidRenderSettings().isSolidRenderingEnabled();
     projector = new DefaultPointProjector();
-    if (pLayer.getGradientMapFilename() != null && pLayer.getGradientMapFilename().length() > 0) {
-      colorProvider = new GradientMapColorProvider(pLayer.getGradientMapFilename());
-    }
-    else {
-      colorProvider = pLayer.isSmoothGradient() ? new SmoothColorProvider() : new DefaultColorProvider();
-    }
 
     boolean withLightmaps = ShadowType.areShadowsEnabled(flame.getSolidRenderSettings().getShadowType());
     prj = new XYZProjectedPoint(withLightmaps ? flame.getSolidRenderSettings().getLights().size() : 0);
@@ -229,154 +214,13 @@ public class DefaultRenderIterationState extends RenderIterationState {
   protected int shadowMapPlotBufferIdx[] = initShadowMapPlotBufferIdx();
   protected PlotSample[][] shadowMapPlotBuffer = initShadowMapPlotBuffer();
 
-  interface ColorProvider extends Serializable {
-    RenderColor getColor(XYZPoint pTPoint, XYZPoint pFPoint);
-  }
-
-  private class DefaultColorProvider implements ColorProvider {
-    private static final long serialVersionUID = 1L;
-
-    @Override
-    public RenderColor getColor(XYZPoint pTPoint, XYZPoint pFPoint) {
-      int colorIdx = (int) (pTPoint.color * paletteIdxScl + 0.5);
-      if (colorIdx < 0)
-        colorIdx = 0;
-      else if (colorIdx >= RGBPalette.PALETTE_SIZE)
-        colorIdx = RGBPalette.PALETTE_SIZE - 1;
-      return colorMap[colorIdx];
-    }
-
-  }
-
-  private class SmoothColorProvider implements ColorProvider {
-    private static final long serialVersionUID = 1L;
-
-    private final RenderColor rc = new RenderColor();
-
-    @Override
-    public RenderColor getColor(XYZPoint pTPoint, XYZPoint pFPoint) {
-      double colorIdx = pTPoint.color * paletteIdxScl;
-      int lIdx = (int) colorIdx;
-      double lR, lG, lB;
-      if (lIdx >= 0 && lIdx < RGBPalette.PALETTE_SIZE) {
-        lR = colorMap[lIdx].red;
-        lG = colorMap[lIdx].green;
-        lB = colorMap[lIdx].blue;
-      }
-      else {
-        lR = lG = lB = 0.0;
-      }
-
-      double rR, rG, rB;
-      int rIdx = lIdx + 1;
-      if (rIdx >= 0 && rIdx < RGBPalette.PALETTE_SIZE) {
-        rR = colorMap[rIdx].red;
-        rG = colorMap[rIdx].green;
-        rB = colorMap[rIdx].blue;
-      }
-      else {
-        rR = rG = rB = 0.0;
-      }
-
-      double t = MathLib.frac(colorIdx);
-      rc.red = GfxMathLib.lerp(lR, rR, t);
-      rc.green = GfxMathLib.lerp(lG, rG, t);
-      rc.blue = GfxMathLib.lerp(lB, rB, t);
-      return rc;
-    }
-  }
-
-  private class GradientMapColorProvider implements ColorProvider {
-    private static final long serialVersionUID = 1L;
-    private final SimpleImage map;
-
-    private SimpleImage createDfltImage() {
-      GradientCreator creator = new GradientCreator();
-      return creator.createImage(256, 256);
-    }
-
-    private final Pixel toolPixel = new Pixel();
-    private final RenderColor rc = new RenderColor();
-
-    public GradientMapColorProvider(String pGradientMap) {
-      SimpleImage image;
-      try {
-        image = (SimpleImage) RessourceManager.getImage(pGradientMap);
-      }
-      catch (Exception e) {
-        e.printStackTrace();
-        image = createDfltImage();
-      }
-      map = image;
-    }
-
-    @Override
-    public RenderColor getColor(XYZPoint pTPoint, XYZPoint pFPoint) {
-      double localColorAdd = layer.getGradientMapLocalColorAdd();
-      double localColorMultiply = layer.getGradientMapLocalColorScale();
-
-      double x = (pFPoint.x * (1.0 - localColorMultiply) + pFPoint.x * localColorMultiply * pFPoint.color + localColorAdd * pFPoint.color) * layer.getGradientMapHorizScale() + layer.getGradientMapHorizOffset();
-      double y = (pFPoint.y * (1.0 - localColorMultiply) + pFPoint.y * localColorMultiply * pFPoint.color + localColorAdd * pFPoint.color) * layer.getGradientMapVertScale() + layer.getGradientMapVertOffset();
-
-      double width = map.getImageWidth() - 2;
-      double height = map.getImageHeight() - 2;
-      double fx = MathLib.fabs(x);
-      double imageX = MathLib.fmod(fx * width, width);
-      if (((int) fx) % 2 != 0) {
-        imageX = width - imageX;
-      }
-      double fy = MathLib.fabs(y);
-      double imageY = MathLib.fmod(fy * height, height);
-      if (((int) fy) % 2 != 0) {
-        imageY = height - imageY;
-      }
-
-      toolPixel.setARGBValue(map.getARGBValueIgnoreBounds((int) imageX, (int) imageY));
-      int luR = toolPixel.r;
-      int luG = toolPixel.g;
-      int luB = toolPixel.b;
-
-      toolPixel.setARGBValue(map.getARGBValueIgnoreBounds(((int) imageX) + 1, (int) imageY));
-      int ruR = toolPixel.r;
-      int ruG = toolPixel.g;
-      int ruB = toolPixel.b;
-      toolPixel.setARGBValue(map.getARGBValueIgnoreBounds((int) imageX, ((int) imageY) + 1));
-      int lbR = toolPixel.r;
-      int lbG = toolPixel.g;
-      int lbB = toolPixel.b;
-      toolPixel.setARGBValue(map.getARGBValueIgnoreBounds(((int) imageX) + 1, ((int) imageY) + 1));
-      int rbR = toolPixel.r;
-      int rbG = toolPixel.g;
-      int rbB = toolPixel.b;
-
-      double localX = MathLib.frac(imageX);
-      double localY = MathLib.frac(imageY);
-      rc.red = GfxMathLib.blerp(luR, ruR, lbR, rbR, localX, localY);
-      rc.green = GfxMathLib.blerp(luG, ruG, lbG, rbG, localX, localY);
-      rc.blue = GfxMathLib.blerp(luB, ruB, lbB, rbB, localX, localY);
-      return rc;
-    }
-  }
-
   protected void plotPoint(int screenX, int screenY, double rawX, double rawY, double intensity, XYZPoint origin) {
-    if (p.rgbColor) {
-      plotRed = p.redColor;
-      plotGreen = p.greenColor;
-      plotBlue = p.blueColor;
-    }
-    else if (q.rgbColor) {
-      plotRed = q.redColor;
-      plotGreen = q.greenColor;
-      plotBlue = q.blueColor;
-    }
-    else {
-      RenderColor color = colorProvider.getColor(p, q);
-      plotRed = color.red;
-      plotGreen = color.green;
-      plotBlue = color.blue;
-    }
+    plotRed = origin.redColor;
+    plotGreen = origin.greenColor;
+    plotBlue = origin.blueColor;
+
     if (!solidRendering)
-      transformPlotColor(p);
+      transformPlotColor(origin);
     double finalRed = plotRed * intensity;
     double finalGreen = plotGreen * intensity;
     double finalBlue = plotBlue * intensity;

--- a/src/org/jwildfire/create/tina/render/DefaultRenderIterationState.java
+++ b/src/org/jwildfire/create/tina/render/DefaultRenderIterationState.java
@@ -220,7 +220,7 @@ public class DefaultRenderIterationState extends RenderIterationState {
     plotBlue = origin.blueColor;
 
     if (!solidRendering)
-      transformPlotColor(origin);
+      transformPlotColor(p);
     double finalRed = plotRed * intensity;
     double finalGreen = plotGreen * intensity;
     double finalBlue = plotBlue * intensity;

--- a/src/org/jwildfire/create/tina/render/PostBlurRenderIterationState.java
+++ b/src/org/jwildfire/create/tina/render/PostBlurRenderIterationState.java
@@ -71,18 +71,10 @@ public class PostBlurRenderIterationState extends DefaultRenderIterationState {
 
   @Override
   protected void plotPoint(int screenX, int screenY, double rawX, double rawY, double intensity, XYZPoint origin) {
-    if (p.rgbColor) {
-      plotRed = p.redColor;
-      plotGreen = p.greenColor;
-      plotBlue = p.blueColor;
-    }
-    else {
-      RenderColor color = colorProvider.getColor(p, q);
-      plotRed = color.red;
-      plotGreen = color.green;
-      plotBlue = color.blue;
-    }
-    transformPlotColor(p);
+    plotRed = origin.redColor;
+    plotGreen = origin.greenColor;
+    plotBlue = origin.blueColor;
+    transformPlotColor(origin);
 
     if (ctx.random() > blurFade) {
       for (int k = screenY - blurRadius, yk = 0; k <= screenY + blurRadius; k++, yk++) {

--- a/src/org/jwildfire/create/tina/script/swing/JWFScriptController.java
+++ b/src/org/jwildfire/create/tina/script/swing/JWFScriptController.java
@@ -20,6 +20,7 @@ import org.jwildfire.base.MacroButton;
 import org.jwildfire.base.Prefs;
 import org.jwildfire.base.Tools;
 import org.jwildfire.create.tina.base.DrawMode;
+import org.jwildfire.create.tina.base.ColorType;
 import org.jwildfire.create.tina.base.Flame;
 import org.jwildfire.create.tina.base.Layer;
 import org.jwildfire.create.tina.base.XForm;
@@ -408,6 +409,7 @@ public class JWFScriptController {
     sb.append("import org.jwildfire.create.tina.transform.XFormTransformService;\n");
     sb.append("import org.jwildfire.create.tina.base.Layer;\n");
     sb.append("import org.jwildfire.create.tina.base.DrawMode;\n");
+    sb.append("import org.jwildfire.create.tina.base.ColorType;\n");
     sb.append("import org.jwildfire.create.tina.variation.Variation;\n");
     sb.append("import org.jwildfire.create.tina.variation.VariationFunc;\n");
     sb.append("import org.jwildfire.create.tina.variation.VariationFuncList;\n");
@@ -596,6 +598,18 @@ public class JWFScriptController {
     case OPAQUE:
       pSB.append("      xForm.setDrawMode(DrawMode.OPAQUE);\n");
       pSB.append("      xForm.setOpacity(" + Tools.doubleToString(pXForm.getOpacity()) + ");\n");
+      break;
+    }
+    switch (pXForm.getColorType()) {
+    case NONE:
+      if (!pFinalXForm) {
+        pSB.append("      xForm.setColorType(ColorType.NONE);\n");
+      }
+      break;
+    case DIFFUSION:
+      if (pFinalXForm) {
+        pSB.append("      xForm.setColorType(ColorType.DIFFUSION);\n");
+      }
       break;
     }
     pSB.append("      xForm.setMaterial(" + Tools.doubleToString(pXForm.getMaterial()) + ");\n");

--- a/src/org/jwildfire/create/tina/script/swing/JWFScriptController.java
+++ b/src/org/jwildfire/create/tina/script/swing/JWFScriptController.java
@@ -602,9 +602,7 @@ public class JWFScriptController {
     }
     switch (pXForm.getColorType()) {
     case NONE:
-      if (!pFinalXForm) {
-        pSB.append("      xForm.setColorType(ColorType.NONE);\n");
-      }
+      pSB.append("      xForm.setColorType(ColorType.NONE);\n");
       break;
     case DIFFUSION:
       if (pFinalXForm) {

--- a/src/org/jwildfire/create/tina/swing/MainEditorFrame.java
+++ b/src/org/jwildfire/create/tina/swing/MainEditorFrame.java
@@ -79,6 +79,7 @@ import org.jwildfire.create.tina.animate.SequenceOutputType;
 import org.jwildfire.create.tina.animate.XFormScriptType;
 import org.jwildfire.create.tina.base.BGColorType;
 import org.jwildfire.create.tina.base.DrawMode;
+import org.jwildfire.create.tina.base.ColorType;
 import org.jwildfire.create.tina.base.EditPlane;
 import org.jwildfire.create.tina.base.PostSymmetryType;
 import org.jwildfire.create.tina.base.Stereo3dColor;
@@ -381,7 +382,9 @@ public class MainEditorFrame extends JFrame {
   private JWFNumberField xFormOpacityREd = null;
   private JSlider xFormOpacitySlider = null;
   private JLabel xFormDrawModeLbl = null;
+  private JLabel xFormColorTypeLbl = null;
   private JComboBox xFormDrawModeCmb = null;
+  private JComboBox xFormColorTypeCmb = null;
   private JPanel relWeightsEastPanel = null;
   private JButton relWeightsZeroButton = null;
   private JButton relWeightsOneButton = null;
@@ -4166,14 +4169,21 @@ public class MainEditorFrame extends JFrame {
       xFormDrawModeLbl.setPreferredSize(new Dimension(64, 22));
       xFormDrawModeLbl.setText("Draw mode");
       xFormDrawModeLbl.setSize(new Dimension(119, 22));
-      xFormDrawModeLbl.setLocation(new Point(6, 75));
+      xFormDrawModeLbl.setLocation(new Point(6, 101));
       xFormDrawModeLbl.setFont(Prefs.getPrefs().getFont("Dialog", Font.BOLD, 10));
+      xFormColorTypeLbl = new JLabel();
+      xFormColorTypeLbl.setToolTipText("");
+      xFormColorTypeLbl.setPreferredSize(new Dimension(64, 22));
+      xFormColorTypeLbl.setText("Color Type");
+      xFormColorTypeLbl.setSize(new Dimension(119, 22));
+      xFormColorTypeLbl.setLocation(new Point(6, 10));
+      xFormColorTypeLbl.setFont(Prefs.getPrefs().getFont("Dialog", Font.BOLD, 10));
       xFormOpacityLbl = new JLabel();
       xFormOpacityLbl.setName("xFormOpacityLbl");
       xFormOpacityLbl.setPreferredSize(new Dimension(64, 22));
       xFormOpacityLbl.setText("Opacity");
       xFormOpacityLbl.setSize(new Dimension(49, 22));
-      xFormOpacityLbl.setLocation(new Point(6, 101));
+      xFormOpacityLbl.setLocation(new Point(6, 127));
       xFormOpacityLbl.setFont(Prefs.getPrefs().getFont("Dialog", Font.BOLD, 10));
       xFormSymmetryLbl = new JLabel();
       xFormSymmetryLbl.setName("xFormSymmetryLbl");
@@ -4181,14 +4191,14 @@ public class MainEditorFrame extends JFrame {
       xFormSymmetryLbl.setPreferredSize(new Dimension(64, 22));
       xFormSymmetryLbl.setText("Speed");
       xFormSymmetryLbl.setSize(new Dimension(49, 22));
-      xFormSymmetryLbl.setLocation(new Point(6, 47));
+      xFormSymmetryLbl.setLocation(new Point(6, 73));
       xFormSymmetryLbl.setFont(Prefs.getPrefs().getFont("Dialog", Font.BOLD, 10));
       xFormColorLbl = new JLabel();
       xFormColorLbl.setName("xFormColorLbl");
       xFormColorLbl.setPreferredSize(new Dimension(64, 22));
       xFormColorLbl.setText("Color");
       xFormColorLbl.setSize(new Dimension(49, 22));
-      xFormColorLbl.setLocation(new Point(6, 21));
+      xFormColorLbl.setLocation(new Point(6, 47));
       xFormColorLbl.setFont(Prefs.getPrefs().getFont("Dialog", Font.BOLD, 10));
       tinaTransformationColorPanel = new JPanel();
       tinaTransformationColorPanel.setLayout(null);
@@ -4203,9 +4213,11 @@ public class MainEditorFrame extends JFrame {
       tinaTransformationColorPanel.add(getXFormOpacitySlider(), null);
       tinaTransformationColorPanel.add(xFormDrawModeLbl, null);
       tinaTransformationColorPanel.add(getXFormDrawModeCmb(), null);
+      tinaTransformationColorPanel.add(xFormColorTypeLbl, null);
+      tinaTransformationColorPanel.add(getXFormColorTypeCmb(), null);
 
       tinaColorChooserPaletteImgPanel = new JPanel();
-      tinaColorChooserPaletteImgPanel.setBounds(125, 10, 195, 10);
+      tinaColorChooserPaletteImgPanel.setBounds(125, 36, 195, 10);
       tinaTransformationColorPanel.add(tinaColorChooserPaletteImgPanel);
       tinaColorChooserPaletteImgPanel.setLayout(new BorderLayout(0, 0));
 
@@ -4214,9 +4226,9 @@ public class MainEditorFrame extends JFrame {
       xFormMaterialLbl.setSize(new Dimension(49, 22));
       xFormMaterialLbl.setPreferredSize(new Dimension(64, 22));
       xFormMaterialLbl.setName("xFormMaterialLbl");
-      xFormMaterialLbl.setLocation(new Point(6, 21));
+      xFormMaterialLbl.setLocation(new Point(6, 172));
       xFormMaterialLbl.setFont(Prefs.getPrefs().getFont("Dialog", Font.BOLD, 10));
-      xFormMaterialLbl.setBounds(6, 146, 49, 22);
+//      xFormMaterialLbl.setBounds(6, 146, 49, 22);
       tinaTransformationColorPanel.add(xFormMaterialLbl);
 
       xFormMaterialREd = new JWFNumberField();
@@ -4225,13 +4237,13 @@ public class MainEditorFrame extends JFrame {
       xFormMaterialREd.setSize(new Dimension(70, 24));
       xFormMaterialREd.setPreferredSize(new Dimension(70, 24));
       xFormMaterialREd.setMotionPropertyName("material");
-      xFormMaterialREd.setLocation(new Point(55, 21));
+      xFormMaterialREd.setLocation(new Point(55, 172));
       xFormMaterialREd.setLinkedMotionControlName("xFormMaterialSlider");
       xFormMaterialREd.setLinkedLabelControlName("xFormMaterialLbl");
       xFormMaterialREd.setHasMinValue(true);
       xFormMaterialREd.setHasMaxValue(false);
       xFormMaterialREd.setFont(Prefs.getPrefs().getFont("Dialog", Font.PLAIN, 10));
-      xFormMaterialREd.setBounds(55, 146, 70, 24);
+//      xFormMaterialREd.setBounds(55, 146, 70, 24);
       xFormMaterialREd.addActionListener(new ActionListener() {
         public void actionPerformed(ActionEvent e) {
           tinaController.getXFormControls().editMotionCurve(e);
@@ -4258,9 +4270,9 @@ public class MainEditorFrame extends JFrame {
       xFormMaterialSlider.setName("xFormMaterialSlider");
       xFormMaterialSlider.setMinimum(0);
       xFormMaterialSlider.setMaximum(300);
-      xFormMaterialSlider.setLocation(new Point(125, 21));
+      xFormMaterialSlider.setLocation(new Point(125, 172));
       xFormMaterialSlider.setFont(Prefs.getPrefs().getFont("Dialog", Font.BOLD, 10));
-      xFormMaterialSlider.setBounds(125, 146, 195, 22);
+//      xFormMaterialSlider.setBounds(125, 146, 195, 22);
       xFormMaterialSlider.addMouseListener(new MouseAdapter() {
         @Override
         public void mousePressed(MouseEvent e) {
@@ -4275,7 +4287,7 @@ public class MainEditorFrame extends JFrame {
       tinaTransformationColorPanel.add(xFormMaterialSlider);
 
       tinaMaterialChooserPaletteImgPanel = new JPanel();
-      tinaMaterialChooserPaletteImgPanel.setBounds(125, 135, 195, 10);
+      tinaMaterialChooserPaletteImgPanel.setBounds(125, 161, 195, 10);
       tinaTransformationColorPanel.add(tinaMaterialChooserPaletteImgPanel);
       tinaMaterialChooserPaletteImgPanel.setLayout(new BorderLayout(0, 0));
 
@@ -4285,9 +4297,9 @@ public class MainEditorFrame extends JFrame {
       xFormMaterialSpeedLbl.setSize(new Dimension(49, 22));
       xFormMaterialSpeedLbl.setPreferredSize(new Dimension(64, 22));
       xFormMaterialSpeedLbl.setName("xFormMaterialSpeedLbl");
-      xFormMaterialSpeedLbl.setLocation(new Point(6, 47));
+      xFormMaterialSpeedLbl.setLocation(new Point(6, 198));
       xFormMaterialSpeedLbl.setFont(Prefs.getPrefs().getFont("Dialog", Font.BOLD, 10));
-      xFormMaterialSpeedLbl.setBounds(6, 172, 49, 22);
+//      xFormMaterialSpeedLbl.setBounds(6, 172, 49, 22);
       tinaTransformationColorPanel.add(xFormMaterialSpeedLbl);
 
       xFormMaterialSpeedREd = new JWFNumberField();
@@ -4298,13 +4310,13 @@ public class MainEditorFrame extends JFrame {
       xFormMaterialSpeedREd.setMotionPropertyName("materialSpeed");
       xFormMaterialSpeedREd.setMinValue(-1.0);
       xFormMaterialSpeedREd.setMaxValue(1.0);
-      xFormMaterialSpeedREd.setLocation(new Point(55, 47));
+      xFormMaterialSpeedREd.setLocation(new Point(55, 198));
       xFormMaterialSpeedREd.setLinkedMotionControlName("xFormMaterialSpeedSlider");
       xFormMaterialSpeedREd.setLinkedLabelControlName("xFormMaterialSpeedLbl");
       xFormMaterialSpeedREd.setHasMinValue(true);
       xFormMaterialSpeedREd.setHasMaxValue(true);
       xFormMaterialSpeedREd.setFont(Prefs.getPrefs().getFont("Dialog", Font.PLAIN, 10));
-      xFormMaterialSpeedREd.setBounds(55, 172, 70, 24);
+//      xFormMaterialSpeedREd.setBounds(55, 172, 70, 24);
       xFormMaterialSpeedREd.addActionListener(new ActionListener() {
         public void actionPerformed(ActionEvent e) {
           tinaController.getXFormControls().editMotionCurve(e);
@@ -4332,9 +4344,9 @@ public class MainEditorFrame extends JFrame {
       xFormMaterialSpeedSlider.setName("xFormMaterialSpeedSlider");
       xFormMaterialSpeedSlider.setMinimum(-100);
       xFormMaterialSpeedSlider.setMaximum(100);
-      xFormMaterialSpeedSlider.setLocation(new Point(125, 47));
+      xFormMaterialSpeedSlider.setLocation(new Point(125, 198));
       xFormMaterialSpeedSlider.setFont(Prefs.getPrefs().getFont("Dialog", Font.BOLD, 10));
-      xFormMaterialSpeedSlider.setBounds(125, 172, 195, 22);
+//      xFormMaterialSpeedSlider.setBounds(125, 172, 195, 22);
       xFormMaterialSpeedSlider.addMouseListener(new MouseAdapter() {
         @Override
         public void mousePressed(MouseEvent e) {
@@ -5424,7 +5436,7 @@ public class MainEditorFrame extends JFrame {
         getTinaAddLinkedTransformationButton(),
         getTinaDuplicateTransformationButton(), getTinaDeleteTransformationButton(), getTinaAddFinalTransformationButton(), getRandomBatchPanel(),
         nonlinearControlsRows, getXFormColorREd(), getXFormColorSlider(), getXFormSymmetryREd(), getXFormSymmetrySlider(), getXFormOpacityREd(),
-        getXFormOpacitySlider(), getXFormDrawModeCmb(), getRelWeightsTable(), getRelWeightsZeroButton(), getRelWeightsOneButton(), getRelWeightREd(),
+        getXFormOpacitySlider(), getXFormDrawModeCmb(), getXFormColorTypeCmb(), getRelWeightsTable(), getRelWeightsZeroButton(), getRelWeightsOneButton(), getRelWeightREd(),
         getMouseTransformMoveTrianglesButton(),
         getMouseTransformEditFocusPointButton(), getMouseTransformShearButton(), getMouseTransformViewButton(),
         getAffineEditPostTransformButton(), getAffineEditPostTransformSmallButton(),
@@ -5575,6 +5587,10 @@ public class MainEditorFrame extends JFrame {
       getXFormDrawModeCmb().addItem(DrawMode.NORMAL);
       getXFormDrawModeCmb().addItem(DrawMode.OPAQUE);
       getXFormDrawModeCmb().addItem(DrawMode.HIDDEN);
+      
+      getXFormColorTypeCmb().removeAllItems();
+      getXFormColorTypeCmb().addItem(ColorType.NONE);
+      getXFormColorTypeCmb().addItem(ColorType.DIFFUSION);
 
       getTinaSolidRenderingMaterialDiffuseResponseCmb().removeAllItems();
       getTinaSolidRenderingMaterialDiffuseResponseCmb().addItem(LightDiffFuncPreset.COSA);
@@ -7237,7 +7253,7 @@ public class MainEditorFrame extends JFrame {
       xFormColorREd.setPreferredSize(new Dimension(70, 24));
       xFormColorREd.setText("");
       xFormColorREd.setSize(new Dimension(70, 24));
-      xFormColorREd.setLocation(new Point(55, 21));
+      xFormColorREd.setLocation(new Point(55, 47));
       xFormColorREd.setFont(Prefs.getPrefs().getFont("Dialog", Font.PLAIN, 10));
     }
     return xFormColorREd;
@@ -7257,7 +7273,7 @@ public class MainEditorFrame extends JFrame {
       xFormColorSlider.setMinimum(0);
       xFormColorSlider.setValue(0);
       xFormColorSlider.setSize(new Dimension(195, 22));
-      xFormColorSlider.setLocation(new Point(125, 21));
+      xFormColorSlider.setLocation(new Point(125, 47));
       xFormColorSlider.setFont(Prefs.getPrefs().getFont("Dialog", Font.BOLD, 10));
       xFormColorSlider.addMouseListener(new MouseAdapter() {
         @Override
@@ -7310,7 +7326,7 @@ public class MainEditorFrame extends JFrame {
       xFormSymmetryREd.setPreferredSize(new Dimension(55, 24));
       xFormSymmetryREd.setText("");
       xFormSymmetryREd.setSize(new Dimension(70, 24));
-      xFormSymmetryREd.setLocation(new Point(55, 47));
+      xFormSymmetryREd.setLocation(new Point(55, 73));
       xFormSymmetryREd.setFont(Prefs.getPrefs().getFont("Dialog", Font.PLAIN, 10));
     }
     return xFormSymmetryREd;
@@ -7329,7 +7345,7 @@ public class MainEditorFrame extends JFrame {
       xFormSymmetrySlider.setMaximum(100);
       xFormSymmetrySlider.setMinimum(-100);
       xFormSymmetrySlider.setValue(0);
-      xFormSymmetrySlider.setLocation(new Point(125, 47));
+      xFormSymmetrySlider.setLocation(new Point(125, 73));
       xFormSymmetrySlider.setSize(new Dimension(195, 22));
       xFormSymmetrySlider.setFont(Prefs.getPrefs().getFont("Dialog", Font.BOLD, 10));
       xFormSymmetrySlider.addMouseListener(new MouseAdapter() {
@@ -7382,7 +7398,7 @@ public class MainEditorFrame extends JFrame {
       xFormOpacityREd.setPreferredSize(new Dimension(55, 24));
       xFormOpacityREd.setText("");
       xFormOpacityREd.setSize(new Dimension(70, 24));
-      xFormOpacityREd.setLocation(new Point(55, 101));
+      xFormOpacityREd.setLocation(new Point(55, 127));
       xFormOpacityREd.setFont(Prefs.getPrefs().getFont("Dialog", Font.PLAIN, 10));
     }
     return xFormOpacityREd;
@@ -7408,7 +7424,7 @@ public class MainEditorFrame extends JFrame {
       xFormOpacitySlider.setMinimum(0);
       xFormOpacitySlider.setValue(0);
       xFormOpacitySlider.setSize(new Dimension(195, 22));
-      xFormOpacitySlider.setLocation(new Point(125, 101));
+      xFormOpacitySlider.setLocation(new Point(125, 127));
       xFormOpacitySlider.setFont(Prefs.getPrefs().getFont("Dialog", Font.BOLD, 10));
       xFormOpacitySlider.addChangeListener(new javax.swing.event.ChangeListener() {
         public void stateChanged(javax.swing.event.ChangeEvent e) {
@@ -7429,7 +7445,7 @@ public class MainEditorFrame extends JFrame {
       xFormDrawModeCmb = new JComboBox();
       xFormDrawModeCmb.setPreferredSize(new Dimension(120, 22));
       xFormDrawModeCmb.setSize(new Dimension(120, 22));
-      xFormDrawModeCmb.setLocation(new Point(122, 77));
+      xFormDrawModeCmb.setLocation(new Point(122, 103));
       xFormDrawModeCmb.setFont(Prefs.getPrefs().getFont("Dialog", Font.BOLD, 10));
       xFormDrawModeCmb.addItemListener(new java.awt.event.ItemListener() {
         public void itemStateChanged(java.awt.event.ItemEvent e) {
@@ -7439,6 +7455,28 @@ public class MainEditorFrame extends JFrame {
       });
     }
     return xFormDrawModeCmb;
+  }
+
+  /**
+   * This method initializes xFormColorTypeCmb   
+   *    
+   * @return javax.swing.JComboBox  
+   */
+  private JComboBox getXFormColorTypeCmb() {
+    if (xFormColorTypeCmb == null) {
+      xFormColorTypeCmb = new JComboBox();
+      xFormColorTypeCmb.setPreferredSize(new Dimension(120, 22));
+      xFormColorTypeCmb.setSize(new Dimension(120, 22));
+      xFormColorTypeCmb.setLocation(new Point(122, 10));
+      xFormColorTypeCmb.setFont(Prefs.getPrefs().getFont("Dialog", Font.BOLD, 10));
+      xFormColorTypeCmb.addItemListener(new java.awt.event.ItemListener() {
+        public void itemStateChanged(java.awt.event.ItemEvent e) {
+          tinaController.saveUndoPoint();
+          tinaController.xFormColorTypeCmb_changed();
+        }
+      });
+    }
+    return xFormColorTypeCmb;
   }
 
   /**

--- a/src/org/jwildfire/create/tina/swing/TinaController.java
+++ b/src/org/jwildfire/create/tina/swing/TinaController.java
@@ -79,6 +79,7 @@ import org.jwildfire.create.tina.AnimationController;
 import org.jwildfire.create.tina.GradientController;
 import org.jwildfire.create.tina.base.BGColorType;
 import org.jwildfire.create.tina.base.DrawMode;
+import org.jwildfire.create.tina.base.ColorType;
 import org.jwildfire.create.tina.base.EditPlane;
 import org.jwildfire.create.tina.base.Flame;
 import org.jwildfire.create.tina.base.Layer;
@@ -569,6 +570,7 @@ public class TinaController implements FlameHolder, LayerHolder, ScriptRunnerEnv
     data.xFormOpacityREd = parameterObject.pXFormOpacityREd;
     data.xFormOpacitySlider = parameterObject.pXFormOpacitySlider;
     data.xFormDrawModeCmb = parameterObject.pXFormDrawModeCmb;
+    data.xFormColorTypeCmb = parameterObject.pXFormColorTypeCmb;
 
     data.xFormAntialiasAmountREd = parameterObject.pXFormAntialiasAmountREd;
     data.xFormAntialiasAmountSlider = parameterObject.pXFormAntialiasAmountSlider;
@@ -2577,6 +2579,7 @@ public class TinaController implements FlameHolder, LayerHolder, ScriptRunnerEnv
         data.xFormOpacityREd.setText(Tools.doubleToString(pXForm.getOpacity()));
         data.xFormOpacitySlider.setValue(Tools.FTOI(pXForm.getOpacity() * SLIDER_SCALE_COLOR));
         data.xFormDrawModeCmb.setSelectedItem(pXForm.getDrawMode());
+        data.xFormColorTypeCmb.setSelectedItem(pXForm.getColorType());
 
         data.transformationWeightREd.setText(Tools.doubleToString(pXForm.getWeight()));
       }
@@ -2615,6 +2618,7 @@ public class TinaController implements FlameHolder, LayerHolder, ScriptRunnerEnv
         data.xFormOpacitySlider.setValue(0);
         data.transformationWeightREd.setText(null);
         data.xFormDrawModeCmb.setSelectedIndex(-1);
+        data.xFormColorTypeCmb.setSelectedIndex(-1);
       }
 
       {
@@ -2869,6 +2873,7 @@ public class TinaController implements FlameHolder, LayerHolder, ScriptRunnerEnv
     XForm xForm = new XForm();
     xForm.addVariation(1.0, new Linear3DFunc());
     xForm.setColorSymmetry(1.0);
+    xForm.setColorType(ColorType.NONE);
     saveUndoPoint();
     getCurrLayer().getFinalXForms().add(xForm);
     gridRefreshing = true;
@@ -3647,6 +3652,17 @@ public class TinaController implements FlameHolder, LayerHolder, ScriptRunnerEnv
       XForm xForm = getCurrXForm();
       if (xForm != null && data.xFormDrawModeCmb.getSelectedItem() != null) {
         xForm.setDrawMode((DrawMode) data.xFormDrawModeCmb.getSelectedItem());
+        refreshFlameImage(true, false, 1, true, false);
+        xFormControls.enableControls(xForm);
+      }
+    }
+  }
+
+  public void xFormColorTypeCmb_changed() {
+    if (!cmbRefreshing) {
+      XForm xForm = getCurrXForm();
+      if (xForm != null && data.xFormColorTypeCmb.getSelectedItem() != null) {
+        xForm.setColorType((ColorType) data.xFormColorTypeCmb.getSelectedItem());
         refreshFlameImage(true, false, 1, true, false);
         xFormControls.enableControls(xForm);
       }

--- a/src/org/jwildfire/create/tina/swing/TinaController.java
+++ b/src/org/jwildfire/create/tina/swing/TinaController.java
@@ -1486,6 +1486,9 @@ public class TinaController implements FlameHolder, LayerHolder, ScriptRunnerEnv
       public Object getValueAt(int rowIndex, int columnIndex) {
         if (getCurrFlame() != null) {
           XForm xForm = rowIndex < getCurrLayer().getXForms().size() ? getCurrLayer().getXForms().get(rowIndex) : getCurrLayer().getFinalXForms().get(rowIndex - getCurrLayer().getXForms().size());
+          if (xForm.getColorType() == ColorType.UNSET) {
+            xForm.setColorType(rowIndex < getCurrLayer().getXForms().size() ? ColorType.DIFFUSION : ColorType.NONE);
+          }
           switch (columnIndex) {
             case COL_TRANSFORM:
               return rowIndex < getCurrLayer().getXForms().size() ? "Transf" + String.valueOf(rowIndex + 1) : "Final" + String.valueOf(rowIndex - getCurrLayer().getXForms().size() + 1);
@@ -2791,6 +2794,7 @@ public class TinaController implements FlameHolder, LayerHolder, ScriptRunnerEnv
     XForm xForm = new XForm();
     xForm.addVariation(1.0, new Linear3DFunc());
     xForm.setWeight(0.5);
+    xForm.setColorType(ColorType.DIFFUSION);
     saveUndoPoint();
     getCurrLayer().getXForms().add(xForm);
     gridRefreshing = true;

--- a/src/org/jwildfire/create/tina/swing/TinaControllerData.java
+++ b/src/org/jwildfire/create/tina/swing/TinaControllerData.java
@@ -248,6 +248,7 @@ public class TinaControllerData {
   public JWFNumberField xFormOpacityREd;
   public JSlider xFormOpacitySlider;
   public JComboBox xFormDrawModeCmb;
+  public JComboBox xFormColorTypeCmb;
   public JWFNumberField xFormAntialiasAmountREd;
   public JSlider xFormAntialiasAmountSlider;
   public JWFNumberField xFormAntialiasRadiusREd;

--- a/src/org/jwildfire/create/tina/swing/TinaControllerParameter.java
+++ b/src/org/jwildfire/create/tina/swing/TinaControllerParameter.java
@@ -201,6 +201,7 @@ public class TinaControllerParameter {
   public JWFNumberField pXFormOpacityREd;
   public JSlider pXFormOpacitySlider;
   public JComboBox pXFormDrawModeCmb;
+  public JComboBox pXFormColorTypeCmb;
   public JTable pRelWeightsTable;
   public JButton pRelWeightsZeroButton;
   public JButton pRelWeightsOneButton;
@@ -725,7 +726,7 @@ public class TinaControllerParameter {
                          JLabel pAffineC00Lbl, JLabel pAffineC01Lbl, JLabel pAffineC10Lbl, JLabel pAffineC11Lbl, JWFNumberField pAffineC00REd, JWFNumberField pAffineC01REd, JWFNumberField pAffineC10REd, JWFNumberField pAffineC11REd, JWFNumberField pAffineC20REd, JWFNumberField pAffineC21REd, JWFNumberField pAffineRotateAmountREd,
                          JWFNumberField pAffineScaleAmountREd, JWFNumberField pAffineMoveHorizAmountREd, JButton pAffineRotateLeftButton, JButton pAffineRotateRightButton, JButton pAffineEnlargeButton, JButton pAffineShrinkButton, JButton pAffineMoveUpButton, JButton pAffineMoveLeftButton, JButton pAffineMoveRightButton, JButton pAffineMoveDownButton, JButton pAddTransformationButton, JButton pAddLinkedTransformationButton, JButton pDuplicateTransformationButton, JButton pDeleteTransformationButton, JButton pAddFinalTransformationButton, JPanel pRandomBatchPanel, TinaNonlinearControlsRow[] pTinaNonlinearControlsRows, JWFNumberField pXFormColorREd, JSlider pXFormColorSlider, JWFNumberField pXFormSymmetryREd, JSlider pXFormSymmetrySlider, JWFNumberField pXFormOpacityREd,
                          JSlider pXFormOpacitySlider,
-                         JComboBox pXFormDrawModeCmb, JTable pRelWeightsTable, JButton pRelWeightsZeroButton, JButton pRelWeightsOneButton, JWFNumberField pRelWeightREd, JToggleButton pMouseTransformMoveButton, JToggleButton pMouseTransformScaleButton, JToggleButton pMouseTransformShearButton, JToggleButton pMouseTransformViewButton, JToggleButton pAffineEditPostTransformButton, JToggleButton pAffineEditPostTransformSmallButton, JButton pAffineResetTransformButton, JTable pCreatePaletteColorsTable,
+                         JComboBox pXFormDrawModeCmb, JComboBox pXFormColorTypeCmb, JTable pRelWeightsTable, JButton pRelWeightsZeroButton, JButton pRelWeightsOneButton, JWFNumberField pRelWeightREd, JToggleButton pMouseTransformMoveButton, JToggleButton pMouseTransformScaleButton, JToggleButton pMouseTransformShearButton, JToggleButton pMouseTransformViewButton, JToggleButton pAffineEditPostTransformButton, JToggleButton pAffineEditPostTransformSmallButton, JButton pAffineResetTransformButton, JTable pCreatePaletteColorsTable,
                          JToggleButton pMouseTransformSlowButton,
                          JPanel pRootPanel, JButton pAffineFlipHorizontalButton, JButton pAffineFlipVerticalButton, JWFNumberField pPostBlurRadiusREd, JSlider pPostBlurRadiusSlider, JWFNumberField pPostBlurFadeREd, JSlider pPostBlurFadeSlider, JWFNumberField pPostBlurFallOffREd, JSlider pPostBlurFallOffSlider,
                          JToggleButton pAffineScaleXButton, JToggleButton pAffineScaleYButton, JPanel pGradientLibraryPanel, JToggleButton pToggleVariationsButton, JToggleButton pToggleTransparencyButton, JToggleButton pAffinePreserveZButton, JToggleButton pAffineMirrorPrePostTranslationsButton, JComboBox pQualityProfileCmb, JComboBox pResolutionProfileCmb, JComboBox pInteractiveResolutionProfileCmb, JButton pRenderFlameButton, JButton pRenderMainButton, JButton pAppendToMovieButton, JWFNumberField pTransformationWeightREd, JButton pUndoButton, JButton pRedoButton, JWFNumberField pXFormAntialiasAmountREd, JSlider pXFormAntialiasAmountSlider, JWFNumberField pXFormAntialiasRadiusREd, JSlider pXFormAntialiasRadiusSlider,
@@ -851,6 +852,7 @@ public class TinaControllerParameter {
     this.pXFormOpacityREd = pXFormOpacityREd;
     this.pXFormOpacitySlider = pXFormOpacitySlider;
     this.pXFormDrawModeCmb = pXFormDrawModeCmb;
+    this.pXFormColorTypeCmb = pXFormColorTypeCmb;
     this.pRelWeightsTable = pRelWeightsTable;
     this.pRelWeightsZeroButton = pRelWeightsZeroButton;
     this.pRelWeightsOneButton = pRelWeightsOneButton;

--- a/src/org/jwildfire/create/tina/swing/XFormControlsDelegate.java
+++ b/src/org/jwildfire/create/tina/swing/XFormControlsDelegate.java
@@ -22,6 +22,7 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 
 import org.jwildfire.create.tina.animate.AnimationService;
+import org.jwildfire.create.tina.base.ColorType;
 import org.jwildfire.create.tina.base.DrawMode;
 import org.jwildfire.create.tina.base.EditPlane;
 import org.jwildfire.create.tina.base.XForm;
@@ -147,10 +148,11 @@ public class XFormControlsDelegate extends AbstractControlsDelegate {
       // rows.getNonlinearParamsLeftButton().setEnabled(enabled);
       // rows.getNonlinearParamsRightButton().setEnabled(enabled);
     }
-    data.xFormColorREd.setEnabled(enabled);
-    data.xFormColorSlider.setEnabled(enabled);
-    data.xFormSymmetryREd.setEnabled(enabled);
-    data.xFormSymmetrySlider.setEnabled(enabled);
+    boolean colorEnabled = enabled && xForm.getColorType() == ColorType.DIFFUSION;
+    data.xFormColorREd.setEnabled(colorEnabled);
+    data.xFormColorSlider.setEnabled(colorEnabled);
+    data.xFormSymmetryREd.setEnabled(colorEnabled);
+    data.xFormSymmetrySlider.setEnabled(colorEnabled);
     data.xFormMaterialREd.setEnabled(enabled);
     data.xFormMaterialSlider.setEnabled(enabled);
     data.xFormMaterialSpeedREd.setEnabled(enabled);
@@ -174,6 +176,7 @@ public class XFormControlsDelegate extends AbstractControlsDelegate {
     data.xFormOpacityREd.setEnabled(enabled && xForm.getDrawMode() == DrawMode.OPAQUE);
     data.xFormOpacitySlider.setEnabled(data.xFormOpacityREd.isEnabled());
     data.xFormDrawModeCmb.setEnabled(enabled);
+    data.xFormColorTypeCmb.setEnabled(enabled);
 
     data.relWeightsTable.setEnabled(enabled);
     enableRelWeightsControls();

--- a/src/org/jwildfire/create/tina/variation/SubFlameWFFunc.java
+++ b/src/org/jwildfire/create/tina/variation/SubFlameWFFunc.java
@@ -196,6 +196,10 @@ public class SubFlameWFFunc extends VariationFunc {
   protected void prefuseIter(FlameTransformationContext pContext) {
     if (flame != null) {
       Layer layer = flame.getFirstLayer();
+      // a compatibility quirk: default for subflame final xforms is DIFFUSION
+      for (XForm xForm: layer.getFinalXForms()) {
+        if (xForm.getColorType() == ColorType.UNSET) xForm.setColorType(ColorType.DIFFUSION);
+      }
       layer.refreshModWeightTables(pContext);
       xf = layer.getXForms().get(0);
       p = new XYZPoint();
@@ -276,16 +280,16 @@ public class SubFlameWFFunc extends VariationFunc {
             pVarTP.color = q.color;
             break;
           case CM_RED:
-            pVarTP.color = pVarTP.redColor / 255.0;
+            pVarTP.color = q.redColor / 255.0;
             break;
           case CM_GREEN:
-            pVarTP.color = pVarTP.greenColor / 255.0;
+            pVarTP.color = q.greenColor / 255.0;
             break;
           case CM_BLUE:
-            pVarTP.color = pVarTP.blueColor / 255.0;
+            pVarTP.color = q.blueColor / 255.0;
             break;
           case CM_BRIGHTNESS:
-            pVarTP.color = (0.2990 * pVarTP.redColor + 0.5880 * pVarTP.greenColor + 0.1130 * pVarTP.blueColor) / 255.0;
+            pVarTP.color = (0.2990 * q.redColor + 0.5880 * q.greenColor + 0.1130 * q.blueColor) / 255.0;
             break;
         }
       }


### PR DESCRIPTION
There are now two coloring types, selectable per transform on the
Color tab:
NONE (the default for final transforms) does not change the color;
this is the way final transforms have traditionally worked in JWildfire

DIFFUSION (the default for normal transforms) uses the Color and
Speed settings with the gradient; this is the standard method for
coloring flames.

Changing the Color Type for final transforms to DIFFUSION allows final
transforms to adjust the colors, as it does in other flame programs.
Changing the Color Type for normal transforms to NONE allows them to
manipulate true color (rgbColor) variations without sucking the color
away.