### PR TITLE
Add new coloring types: TARGET and TARGETG

### DIFF
--- a/src/org/jwildfire/create/tina/base/ColorType.java
+++ b/src/org/jwildfire/create/tina/base/ColorType.java
@@ -17,5 +17,5 @@
 package org.jwildfire.create.tina.base;
 
 public enum ColorType {
-  UNSET, NONE, DIFFUSION
+  UNSET, NONE, DIFFUSION, TARGET, TARGETG
 }

--- a/src/org/jwildfire/create/tina/base/TransformationTargetColorStep.java
+++ b/src/org/jwildfire/create/tina/base/TransformationTargetColorStep.java
@@ -1,0 +1,30 @@
+    package org.jwildfire.create.tina.base;
+    
+    import org.jwildfire.create.tina.variation.FlameTransformationContext;
+    
+    public final class TransformationTargetColorStep extends AbstractTransformationStep {
+      private static final long serialVersionUID = 1L;
+    
+      public TransformationTargetColorStep(XForm pXForm) {
+        super(pXForm);
+      }
+      
+      private double lerp(double a, double b, double t) {
+        return (1 - t) * a + t * b;
+      }
+    
+      @Override
+      public void transform(FlameTransformationContext pContext, XYZPoint pAffineT, XYZPoint pVarT, XYZPoint pSrcPoint, XYZPoint pDstPoint) {
+        
+        if (pDstPoint.rgbColor) {  
+          return;
+        }
+        
+        double t = (xform.getColorSymmetry() + 1.0) / 2.0;
+        pDstPoint.redColor = lerp(xform.targetRenderColor.red, pDstPoint.redColor, t);
+        pDstPoint.greenColor = lerp(xform.targetRenderColor.green, pDstPoint.greenColor, t);
+        pDstPoint.blueColor = lerp(xform.targetRenderColor.blue, pDstPoint.blueColor, t);
+    
+      }
+    
+    }

--- a/src/org/jwildfire/create/tina/io/AbstractFlameReader.java
+++ b/src/org/jwildfire/create/tina/io/AbstractFlameReader.java
@@ -42,6 +42,7 @@ import org.jwildfire.create.tina.base.solidrender.LightDiffFuncPreset;
 import org.jwildfire.create.tina.base.solidrender.MaterialSettings;
 import org.jwildfire.create.tina.base.solidrender.ReflectionMapping;
 import org.jwildfire.create.tina.base.solidrender.ShadowType;
+import org.jwildfire.create.tina.palette.RGBColor;
 import org.jwildfire.create.tina.render.ChannelMixerMode;
 import org.jwildfire.create.tina.render.dof.DOFBlurShape;
 import org.jwildfire.create.tina.render.dof.DOFBlurShapeType;
@@ -859,6 +860,7 @@ public class AbstractFlameReader {
   public static final String ATTR_WEIGHT = "weight";
   public static final String ATTR_COLOR_TYPE = "color_type";
   public static final String ATTR_COLOR = "color";
+  public static final String ATTR_TARGETCOLOR = "targetcolor";
   public static final String ATTR_OPACITY = "opacity";
   public static final String ATTR_XY_COEFS = "coefs";
   public static final String ATTR_XY_POST = "post";
@@ -923,6 +925,14 @@ public class AbstractFlameReader {
     }
     if ((hs = atts.get(ATTR_COLOR)) != null) {
       pXForm.setColor(Double.parseDouble(hs));
+    }
+    if ((hs = atts.get(ATTR_TARGETCOLOR)) != null) {
+      String s[] = hs.split(" ");
+      int r, g, b;
+      r = Tools.roundColor(255.0 * Double.parseDouble(s[0]));
+      g = Tools.roundColor(255.0 * Double.parseDouble(s[1]));
+      b = Tools.roundColor(255.0 * Double.parseDouble(s[2]));
+      pXForm.setTargetColor(new RGBColor(r, g, b));
     }
     if ((hs = atts.get(ATTR_MATERIAL)) != null) {
       pXForm.setMaterial(Double.parseDouble(hs));

--- a/src/org/jwildfire/create/tina/io/AbstractFlameWriter.java
+++ b/src/org/jwildfire/create/tina/io/AbstractFlameWriter.java
@@ -63,6 +63,7 @@ import org.jwildfire.create.tina.base.motion.MotionCurve;
 import org.jwildfire.create.tina.base.solidrender.DistantLight;
 import org.jwildfire.create.tina.base.solidrender.LightDiffFuncPreset;
 import org.jwildfire.create.tina.base.solidrender.MaterialSettings;
+import org.jwildfire.create.tina.palette.RGBColor;
 import org.jwildfire.create.tina.palette.RGBPalette;
 import org.jwildfire.create.tina.render.dof.DOFBlurShape;
 import org.jwildfire.create.tina.variation.Variation;
@@ -74,7 +75,13 @@ public class AbstractFlameWriter {
     List<SimpleXMLBuilder.Attribute<?>> attrList = new ArrayList<SimpleXMLBuilder.Attribute<?>>();
     attrList.add(pXB.createAttr("weight", pXForm.getWeight()));
     if (pXForm.getColorType() != ColorType.UNSET) attrList.add(pXB.createAttr(AbstractFlameReader.ATTR_COLOR_TYPE, pXForm.getColorType().toString()));
-    attrList.add(pXB.createAttr("color", pXForm.getColor()));
+    if (pXForm.getColorType() == ColorType.TARGET) {
+      RGBColor targetColor = pXForm.getTargetColor();
+      attrList.add(pXB.createAttr("targetcolor", (double) targetColor.getRed() / 255.0 + " " + (double) targetColor.getGreen() / 255.0 + " " + (double) targetColor.getBlue() / 255.0));
+    }
+    else {
+      attrList.add(pXB.createAttr("color", pXForm.getColor()));
+    }
     attrList.add(pXB.createAttr("symmetry", pXForm.getColorSymmetry()));
     attrList.add(pXB.createAttr(AbstractFlameReader.ATTR_MIRROR_PRE_POST_TRANSLATIONS, pXForm.getMirrorTranslations() ? 1 : 0));
     attrList.add(pXB.createAttr(AbstractFlameReader.ATTR_MATERIAL, pXForm.getMaterial()));

--- a/src/org/jwildfire/create/tina/palette/RGBColor.java
+++ b/src/org/jwildfire/create/tina/palette/RGBColor.java
@@ -17,6 +17,7 @@
 package org.jwildfire.create.tina.palette;
 
 import java.io.Serializable;
+import java.awt.Color;
 
 import org.jwildfire.base.Tools;
 import org.jwildfire.base.mathlib.MathLib;
@@ -60,7 +61,18 @@ public class RGBColor implements Assignable<RGBColor>, Serializable /*, Comparab
   public void setBlue(int blue) {
     this.blue = blue;
   }
-
+  
+  public Color getColor() {
+    Color color = new Color(red, green, blue);
+    return color;
+  }
+  
+  public void setColor(Color color) {
+    this.red = color.getRed();
+    this.green = color.getGreen();
+    this.blue = color.getBlue();
+  }
+  
   @Override
   public RGBColor makeCopy() {
     RGBColor res = new RGBColor();

--- a/src/org/jwildfire/create/tina/palette/RGBPalette.java
+++ b/src/org/jwildfire/create/tina/palette/RGBPalette.java
@@ -109,15 +109,11 @@ public class RGBPalette implements Assignable<RGBPalette>, Serializable {
     transformColors();
     RenderColor res[] = new RenderColor[PALETTE_SIZE];
     for (int i = 0; i < res.length; i++) {
-      res[i] = new RenderColor();
       RGBColor color = transformedColors[i];
-      int r, g, b;
       if (color != null) {
-        r = color.getRed();
-        g = color.getGreen();
-        b = color.getBlue();
-      }
-      else {
+        res[i] = new RenderColor(pWhiteLevel, color);
+      } else {
+        int r, g, b;
         RGBColor leftColor = null, rightColor = null;
         int leftIdx = i, rightIdx = i;
         while (leftIdx-- >= 0) {
@@ -152,11 +148,8 @@ public class RGBPalette implements Assignable<RGBPalette>, Serializable {
           g = BLACK.getGreen();
           b = BLACK.getBlue();
         }
+        res[i] = new RenderColor(pWhiteLevel, r, g, b);
       }
-      double DFLT_WHITE_LEVEL = 200.0;
-      res[i].red = (r * DFLT_WHITE_LEVEL) / 256.0;
-      res[i].green = (g * DFLT_WHITE_LEVEL) / 256.0;
-      res[i].blue = (b * DFLT_WHITE_LEVEL) / 256.0;
     }
     return res;
   }

--- a/src/org/jwildfire/create/tina/palette/RenderColor.java
+++ b/src/org/jwildfire/create/tina/palette/RenderColor.java
@@ -30,8 +30,27 @@ public class RenderColor {
     this.green = green;
     this.blue = blue;
   }
-
-  @Override
+  
+  public RenderColor(double pWhiteLevel, int red, int green, int blue) {
+    this.setColor(pWhiteLevel, red, green, blue);
+  }
+  
+  public RenderColor(double pWhiteLevel, RGBColor color) {
+    this.setColor(pWhiteLevel, color.getRed(), color.getGreen(), color.getBlue());
+  }
+  
+  public void setColor(double pWhiteLevel, int red, int green, int blue) {
+    double DFLT_WHITE_LEVEL = 200.0;
+    this.red = red * DFLT_WHITE_LEVEL / 256.0;
+    this.green = green * DFLT_WHITE_LEVEL / 256.0;
+    this.blue = blue * DFLT_WHITE_LEVEL / 256.0;
+  }
+  
+  public void setColor(double pWhiteLevel, RGBColor color) {
+    this.setColor(pWhiteLevel, color.getRed(), color.getGreen(), color.getBlue());
+  }
+  
+ @Override
   public int hashCode() {
     final int prime = 31;
     int result = 1;

--- a/src/org/jwildfire/create/tina/script/swing/JWFScriptController.java
+++ b/src/org/jwildfire/create/tina/script/swing/JWFScriptController.java
@@ -30,6 +30,7 @@ import org.jwildfire.create.tina.base.solidrender.MaterialSettings;
 import org.jwildfire.create.tina.base.solidrender.ShadowType;
 import org.jwildfire.create.tina.io.Flam3GradientReader;
 import org.jwildfire.create.tina.io.RGBPaletteReader;
+import org.jwildfire.create.tina.palette.RGBColor;
 import org.jwildfire.create.tina.swing.ScriptEditDialog;
 import org.jwildfire.create.tina.swing.StandardDialogs;
 import org.jwildfire.create.tina.swing.TinaController;
@@ -602,12 +603,21 @@ public class JWFScriptController {
     }
     switch (pXForm.getColorType()) {
     case NONE:
-      pSB.append("      xForm.setColorType(ColorType.NONE);\n");
+      if (!pFinalXForm)
+        pSB.append("      xForm.setColorType(ColorType.NONE);\n");
       break;
     case DIFFUSION:
       if (pFinalXForm) {
         pSB.append("      xForm.setColorType(ColorType.DIFFUSION);\n");
       }
+      break;
+    case TARGET:
+      pSB.append("      xForm.setColorType(ColorType.TARGET);\n");
+      RGBColor tc = pXForm.getTargetColor();
+      pSB.append("      xForm.setTargetColor(" + Tools.intToString(tc.getRed()) + "," + Tools.intToString(tc.getGreen()) + "," + Tools.intToString(tc.getBlue()) +");\n");
+      break;
+    case TARGETG:
+      pSB.append("      xForm.setColorType(ColorType.TARGETG);\n");
       break;
     }
     pSB.append("      xForm.setMaterial(" + Tools.doubleToString(pXForm.getMaterial()) + ");\n");

--- a/src/org/jwildfire/create/tina/swing/MainEditorFrame.java
+++ b/src/org/jwildfire/create/tina/swing/MainEditorFrame.java
@@ -385,6 +385,7 @@ public class MainEditorFrame extends JFrame {
   private JLabel xFormColorTypeLbl = null;
   private JComboBox xFormDrawModeCmb = null;
   private JComboBox xFormColorTypeCmb = null;
+  private JButton xFormTargetColorBtn = null;
   private JPanel relWeightsEastPanel = null;
   private JButton relWeightsZeroButton = null;
   private JButton relWeightsOneButton = null;
@@ -4205,6 +4206,7 @@ public class MainEditorFrame extends JFrame {
       tinaTransformationColorPanel.add(xFormColorLbl, null);
       tinaTransformationColorPanel.add(getXFormColorREd(), null);
       tinaTransformationColorPanel.add(getXFormColorSlider(), null);
+      tinaTransformationColorPanel.add(getXFormTargetColorBtn(), null);
       tinaTransformationColorPanel.add(xFormSymmetryLbl, null);
       tinaTransformationColorPanel.add(getXFormSymmetryREd(), null);
       tinaTransformationColorPanel.add(getXFormSymmetrySlider(), null);
@@ -5436,7 +5438,7 @@ public class MainEditorFrame extends JFrame {
         getTinaAddLinkedTransformationButton(),
         getTinaDuplicateTransformationButton(), getTinaDeleteTransformationButton(), getTinaAddFinalTransformationButton(), getRandomBatchPanel(),
         nonlinearControlsRows, getXFormColorREd(), getXFormColorSlider(), getXFormSymmetryREd(), getXFormSymmetrySlider(), getXFormOpacityREd(),
-        getXFormOpacitySlider(), getXFormDrawModeCmb(), getXFormColorTypeCmb(), getRelWeightsTable(), getRelWeightsZeroButton(), getRelWeightsOneButton(), getRelWeightREd(),
+        getXFormOpacitySlider(), getXFormDrawModeCmb(), getXFormColorTypeCmb(), getXFormTargetColorBtn(), getRelWeightsTable(), getRelWeightsZeroButton(), getRelWeightsOneButton(), getRelWeightREd(),
         getMouseTransformMoveTrianglesButton(),
         getMouseTransformEditFocusPointButton(), getMouseTransformShearButton(), getMouseTransformViewButton(),
         getAffineEditPostTransformButton(), getAffineEditPostTransformSmallButton(),
@@ -5591,6 +5593,8 @@ public class MainEditorFrame extends JFrame {
       getXFormColorTypeCmb().removeAllItems();
       getXFormColorTypeCmb().addItem(ColorType.NONE);
       getXFormColorTypeCmb().addItem(ColorType.DIFFUSION);
+      getXFormColorTypeCmb().addItem(ColorType.TARGET);
+      getXFormColorTypeCmb().addItem(ColorType.TARGETG);
 
       getTinaSolidRenderingMaterialDiffuseResponseCmb().removeAllItems();
       getTinaSolidRenderingMaterialDiffuseResponseCmb().addItem(LightDiffFuncPreset.COSA);
@@ -7477,6 +7481,25 @@ public class MainEditorFrame extends JFrame {
       });
     }
     return xFormColorTypeCmb;
+  }
+  
+  private JButton getXFormTargetColorBtn() {
+    if (xFormTargetColorBtn == null) {
+      xFormTargetColorBtn = new JButton();
+      xFormTargetColorBtn.setToolTipText("Set target color for transform");
+      xFormTargetColorBtn.setPreferredSize(new Dimension(150, 24));
+      xFormTargetColorBtn.setSize(new Dimension(150, 24));
+      xFormTargetColorBtn.setLocation(new Point(55, 47));
+      xFormTargetColorBtn.setFont(Prefs.getPrefs().getFont("Dialog", Font.BOLD, 10));
+      xFormTargetColorBtn.setBackground(Color.BLACK);
+      xFormTargetColorBtn.addActionListener(new java.awt.event.ActionListener() {
+        public void actionPerformed(java.awt.event.ActionEvent e) {
+          tinaController.saveUndoPoint();
+          tinaController.xFormTargetColorBtn_clicked();
+        }
+      });
+    }
+    return xFormTargetColorBtn;
   }
 
   /**

--- a/src/org/jwildfire/create/tina/swing/TinaController.java
+++ b/src/org/jwildfire/create/tina/swing/TinaController.java
@@ -571,6 +571,7 @@ public class TinaController implements FlameHolder, LayerHolder, ScriptRunnerEnv
     data.xFormOpacitySlider = parameterObject.pXFormOpacitySlider;
     data.xFormDrawModeCmb = parameterObject.pXFormDrawModeCmb;
     data.xFormColorTypeCmb = parameterObject.pXFormColorTypeCmb;
+    data.xFormTargetColorBtn = parameterObject.pXFormTargetColorBtn;
 
     data.xFormAntialiasAmountREd = parameterObject.pXFormAntialiasAmountREd;
     data.xFormAntialiasAmountSlider = parameterObject.pXFormAntialiasAmountSlider;
@@ -2583,6 +2584,7 @@ public class TinaController implements FlameHolder, LayerHolder, ScriptRunnerEnv
         data.xFormOpacitySlider.setValue(Tools.FTOI(pXForm.getOpacity() * SLIDER_SCALE_COLOR));
         data.xFormDrawModeCmb.setSelectedItem(pXForm.getDrawMode());
         data.xFormColorTypeCmb.setSelectedItem(pXForm.getColorType());
+        data.xFormTargetColorBtn.setBackground(pXForm.getTargetColor().getColor());
 
         data.transformationWeightREd.setText(Tools.doubleToString(pXForm.getWeight()));
       }
@@ -2622,6 +2624,7 @@ public class TinaController implements FlameHolder, LayerHolder, ScriptRunnerEnv
         data.transformationWeightREd.setText(null);
         data.xFormDrawModeCmb.setSelectedIndex(-1);
         data.xFormColorTypeCmb.setSelectedIndex(-1);
+        data.xFormTargetColorBtn.setBackground(Color.BLACK);
       }
 
       {
@@ -3683,6 +3686,26 @@ public class TinaController implements FlameHolder, LayerHolder, ScriptRunnerEnv
         xFormControls.enableControls(xForm);
       }
     }
+  }
+  
+  public void xFormTargetColorBtn_clicked() {
+    if (!cmbRefreshing) {
+      ResourceManager rm = ResourceManager.all(FilePropertyEditor.class);
+      String title = rm.getString("ColorPropertyEditor.title");
+      XForm xForm = getCurrXForm();
+      Color selectedColor = JColorChooser.showDialog(rootPanel, title, xForm.getTargetColor().getColor());
+      if (selectedColor != null) {
+        xForm.setTargetColor(selectedColor);       
+        refreshTargetColorBtn();
+        refreshFlameImage(true, false, 1, true, false);
+        xFormControls.enableControls(xForm);
+      }
+    }
+  }
+  
+  public void refreshTargetColorBtn() {
+    XForm xForm = getCurrXForm();
+    data.xFormTargetColorBtn.setBackground(xForm.getTargetColor().getColor());
   }
 
   public void xFormColorREd_changed() {

--- a/src/org/jwildfire/create/tina/swing/TinaControllerData.java
+++ b/src/org/jwildfire/create/tina/swing/TinaControllerData.java
@@ -249,6 +249,7 @@ public class TinaControllerData {
   public JSlider xFormOpacitySlider;
   public JComboBox xFormDrawModeCmb;
   public JComboBox xFormColorTypeCmb;
+  public JButton xFormTargetColorBtn;
   public JWFNumberField xFormAntialiasAmountREd;
   public JSlider xFormAntialiasAmountSlider;
   public JWFNumberField xFormAntialiasRadiusREd;

--- a/src/org/jwildfire/create/tina/swing/TinaControllerParameter.java
+++ b/src/org/jwildfire/create/tina/swing/TinaControllerParameter.java
@@ -202,6 +202,7 @@ public class TinaControllerParameter {
   public JSlider pXFormOpacitySlider;
   public JComboBox pXFormDrawModeCmb;
   public JComboBox pXFormColorTypeCmb;
+  public JButton pXFormTargetColorBtn;
   public JTable pRelWeightsTable;
   public JButton pRelWeightsZeroButton;
   public JButton pRelWeightsOneButton;
@@ -726,7 +727,7 @@ public class TinaControllerParameter {
                          JLabel pAffineC00Lbl, JLabel pAffineC01Lbl, JLabel pAffineC10Lbl, JLabel pAffineC11Lbl, JWFNumberField pAffineC00REd, JWFNumberField pAffineC01REd, JWFNumberField pAffineC10REd, JWFNumberField pAffineC11REd, JWFNumberField pAffineC20REd, JWFNumberField pAffineC21REd, JWFNumberField pAffineRotateAmountREd,
                          JWFNumberField pAffineScaleAmountREd, JWFNumberField pAffineMoveHorizAmountREd, JButton pAffineRotateLeftButton, JButton pAffineRotateRightButton, JButton pAffineEnlargeButton, JButton pAffineShrinkButton, JButton pAffineMoveUpButton, JButton pAffineMoveLeftButton, JButton pAffineMoveRightButton, JButton pAffineMoveDownButton, JButton pAddTransformationButton, JButton pAddLinkedTransformationButton, JButton pDuplicateTransformationButton, JButton pDeleteTransformationButton, JButton pAddFinalTransformationButton, JPanel pRandomBatchPanel, TinaNonlinearControlsRow[] pTinaNonlinearControlsRows, JWFNumberField pXFormColorREd, JSlider pXFormColorSlider, JWFNumberField pXFormSymmetryREd, JSlider pXFormSymmetrySlider, JWFNumberField pXFormOpacityREd,
                          JSlider pXFormOpacitySlider,
-                         JComboBox pXFormDrawModeCmb, JComboBox pXFormColorTypeCmb, JTable pRelWeightsTable, JButton pRelWeightsZeroButton, JButton pRelWeightsOneButton, JWFNumberField pRelWeightREd, JToggleButton pMouseTransformMoveButton, JToggleButton pMouseTransformScaleButton, JToggleButton pMouseTransformShearButton, JToggleButton pMouseTransformViewButton, JToggleButton pAffineEditPostTransformButton, JToggleButton pAffineEditPostTransformSmallButton, JButton pAffineResetTransformButton, JTable pCreatePaletteColorsTable,
+                         JComboBox pXFormDrawModeCmb, JComboBox pXFormColorTypeCmb, JButton pXFormTargetColorBtn, JTable pRelWeightsTable, JButton pRelWeightsZeroButton, JButton pRelWeightsOneButton, JWFNumberField pRelWeightREd, JToggleButton pMouseTransformMoveButton, JToggleButton pMouseTransformScaleButton, JToggleButton pMouseTransformShearButton, JToggleButton pMouseTransformViewButton, JToggleButton pAffineEditPostTransformButton, JToggleButton pAffineEditPostTransformSmallButton, JButton pAffineResetTransformButton, JTable pCreatePaletteColorsTable,
                          JToggleButton pMouseTransformSlowButton,
                          JPanel pRootPanel, JButton pAffineFlipHorizontalButton, JButton pAffineFlipVerticalButton, JWFNumberField pPostBlurRadiusREd, JSlider pPostBlurRadiusSlider, JWFNumberField pPostBlurFadeREd, JSlider pPostBlurFadeSlider, JWFNumberField pPostBlurFallOffREd, JSlider pPostBlurFallOffSlider,
                          JToggleButton pAffineScaleXButton, JToggleButton pAffineScaleYButton, JPanel pGradientLibraryPanel, JToggleButton pToggleVariationsButton, JToggleButton pToggleTransparencyButton, JToggleButton pAffinePreserveZButton, JToggleButton pAffineMirrorPrePostTranslationsButton, JComboBox pQualityProfileCmb, JComboBox pResolutionProfileCmb, JComboBox pInteractiveResolutionProfileCmb, JButton pRenderFlameButton, JButton pRenderMainButton, JButton pAppendToMovieButton, JWFNumberField pTransformationWeightREd, JButton pUndoButton, JButton pRedoButton, JWFNumberField pXFormAntialiasAmountREd, JSlider pXFormAntialiasAmountSlider, JWFNumberField pXFormAntialiasRadiusREd, JSlider pXFormAntialiasRadiusSlider,
@@ -853,6 +854,7 @@ public class TinaControllerParameter {
     this.pXFormOpacitySlider = pXFormOpacitySlider;
     this.pXFormDrawModeCmb = pXFormDrawModeCmb;
     this.pXFormColorTypeCmb = pXFormColorTypeCmb;
+    this.pXFormTargetColorBtn = pXFormTargetColorBtn;
     this.pRelWeightsTable = pRelWeightsTable;
     this.pRelWeightsZeroButton = pRelWeightsZeroButton;
     this.pRelWeightsOneButton = pRelWeightsOneButton;

--- a/src/org/jwildfire/create/tina/swing/XFormControlsDelegate.java
+++ b/src/org/jwildfire/create/tina/swing/XFormControlsDelegate.java
@@ -148,9 +148,13 @@ public class XFormControlsDelegate extends AbstractControlsDelegate {
       // rows.getNonlinearParamsLeftButton().setEnabled(enabled);
       // rows.getNonlinearParamsRightButton().setEnabled(enabled);
     }
-    boolean colorEnabled = enabled && xForm.getColorType() == ColorType.DIFFUSION;
-    data.xFormColorREd.setEnabled(colorEnabled);
-    data.xFormColorSlider.setEnabled(colorEnabled);
+    boolean colorEnabled = enabled && (xForm.getColorType() != ColorType.NONE );
+    data.xFormColorREd.setVisible(enabled && xForm.getColorType() != ColorType.TARGET);
+    data.xFormColorREd.setEnabled(colorEnabled && xForm.getColorType() != ColorType.TARGET);
+    data.xFormColorSlider.setVisible(enabled && xForm.getColorType() != ColorType.TARGET);
+    data.xFormColorSlider.setEnabled(colorEnabled && xForm.getColorType() != ColorType.TARGET);
+    data.xFormTargetColorBtn.setVisible(enabled && xForm.getColorType() == ColorType.TARGET);
+    data.xFormTargetColorBtn.setEnabled(enabled && xForm.getColorType() == ColorType.TARGET);
     data.xFormSymmetryREd.setEnabled(colorEnabled);
     data.xFormSymmetrySlider.setEnabled(colorEnabled);
     data.xFormMaterialREd.setEnabled(enabled);


### PR DESCRIPTION
TARGET ignores the gradient, but uses a specific color that can be set
by clicking a new TargetColor button. The new color is interpolated from
the current color and the target color. Speed works the same as with
DIFFUSION coloring; -1 sets the new color to the target color, 1 doesn't
change the color, and 0 sets the new color halfway between the current
and target colors.

TARGETG works just like TARGET, but the gradient is used to select the
target color, allowing it to be easily changed by changing or shifting
the gradient. But the intermediate gradient colors are not used.

These coloring types can create very smooth color changes in flames, and
also work with variations that set the RGB color values directly.