### PR TITLE
Add new coloring type: DISTANCE

### DIFF
--- a/src/org/jwildfire/create/tina/base/ColorType.java
+++ b/src/org/jwildfire/create/tina/base/ColorType.java
@@ -17,5 +17,5 @@
 package org.jwildfire.create.tina.base;
 
 public enum ColorType {
-  UNSET, NONE, DIFFUSION, TARGET, TARGETG
+  UNSET, NONE, DIFFUSION, TARGET, TARGETG, DISTANCE
 }

--- a/src/org/jwildfire/create/tina/base/TransformationDistanceColorStep.java
+++ b/src/org/jwildfire/create/tina/base/TransformationDistanceColorStep.java
@@ -1,0 +1,35 @@
+package org.jwildfire.create.tina.base;
+
+import static org.jwildfire.base.mathlib.MathLib.sqrt;
+import static org.jwildfire.base.mathlib.MathLib.sqr;
+import org.jwildfire.create.tina.palette.RenderColor;
+import org.jwildfire.create.tina.palette.RGBPalette;
+import org.jwildfire.create.tina.variation.FlameTransformationContext;
+
+public final class TransformationDistanceColorStep extends AbstractTransformationStep {
+  private static final long serialVersionUID = 1L;
+
+  public TransformationDistanceColorStep(XForm pXForm) {
+    super(pXForm);
+  }
+
+  @Override
+  public void transform(FlameTransformationContext pContext, XYZPoint pAffineT, XYZPoint pVarT, XYZPoint pSrcPoint, XYZPoint pDstPoint) {
+    
+    if (pDstPoint.rgbColor) {  
+      return;
+    }
+    
+    double distance = sqrt(sqr(xform.oldx - pDstPoint.x) + sqr(xform.oldy - pDstPoint.y) + sqr(xform.oldz - pDstPoint.z));
+    RenderColor[] colorMap = xform.getOwner().getColorMap();
+    double paletteIdxScl = colorMap.length - 2;
+    int colorIdx = (int) ((xform.getColor() + distance * xform.distMult) * paletteIdxScl + 0.5) % RGBPalette.PALETTE_SIZE;
+    
+    RenderColor color = colorMap[colorIdx];
+    pDstPoint.redColor = color.red;
+    pDstPoint.greenColor = color.green;
+    pDstPoint.blueColor = color.blue;
+
+  }
+
+}

--- a/src/org/jwildfire/create/tina/base/TransformationInitStep.java
+++ b/src/org/jwildfire/create/tina/base/TransformationInitStep.java
@@ -40,5 +40,11 @@ public final class TransformationInitStep extends AbstractTransformationStep {
     pAffineT.modContrast = pSrcPoint.modContrast * xform.modContrast1 + xform.modContrast2;
     pAffineT.modSaturation = pSrcPoint.modSaturation * xform.modSaturation1 + xform.modSaturation2;
     pAffineT.modHue = pSrcPoint.modHue * xform.modHue1 + xform.modHue2;
+    
+    if (xform.getColorType() == ColorType.DISTANCE) {
+      xform.oldx = pSrcPoint.x;
+      xform.oldy = pSrcPoint.y;
+      xform.oldz = pSrcPoint.z;
+    }
   }
 }

--- a/src/org/jwildfire/create/tina/base/XForm.java
+++ b/src/org/jwildfire/create/tina/base/XForm.java
@@ -349,6 +349,8 @@ public final class XForm implements Assignable<XForm>, Serializable {
   double modHue1;
   double modHue2;
   RenderColor targetRenderColor;
+  double distMult;
+  double oldx, oldy, oldz;
 
   public void initTransform() {
     // precalculate those variables to simplify the expression: 
@@ -360,6 +362,9 @@ public final class XForm implements Assignable<XForm>, Serializable {
     if (colorType != ColorType.DIFFUSION && colorType != ColorType.TARGETG) {
       c1 = 1;
       c2 = 0;
+    }
+    if (colorType == ColorType.DISTANCE) {
+      distMult = colorSymmetry + 1;
     }
     if (colorType == ColorType.TARGET) {
       targetRenderColor = new RenderColor(owner.getOwner().getWhiteLevel(), targetColor);
@@ -544,6 +549,9 @@ public final class XForm implements Assignable<XForm>, Serializable {
     }
     else if (colorType == ColorType.TARGET || colorType == ColorType.TARGETG) {
       t.add(new TransformationTargetColorStep(this));
+    }
+    else if (colorType == ColorType.DISTANCE) {
+      t.add(new TransformationDistanceColorStep(this));
     }
 
   }

--- a/src/org/jwildfire/create/tina/script/swing/JWFScriptController.java
+++ b/src/org/jwildfire/create/tina/script/swing/JWFScriptController.java
@@ -619,6 +619,9 @@ public class JWFScriptController {
     case TARGETG:
       pSB.append("      xForm.setColorType(ColorType.TARGETG);\n");
       break;
+    case DISTANCE:
+      pSB.append("      xForm.setColorType(ColorType.DISTANCE);\n");
+      break;
     }
     pSB.append("      xForm.setMaterial(" + Tools.doubleToString(pXForm.getMaterial()) + ");\n");
     pSB.append("      xForm.setMaterialSpeed(" + Tools.doubleToString(pXForm.getMaterialSpeed()) + ");\n");

--- a/src/org/jwildfire/create/tina/swing/MainEditorFrame.java
+++ b/src/org/jwildfire/create/tina/swing/MainEditorFrame.java
@@ -6071,6 +6071,7 @@ public class MainEditorFrame extends JFrame {
       getXFormColorTypeCmb().addItem(ColorType.DIFFUSION);
       getXFormColorTypeCmb().addItem(ColorType.TARGET);
       getXFormColorTypeCmb().addItem(ColorType.TARGETG);
+      getXFormColorTypeCmb().addItem(ColorType.DISTANCE);
 
       getTinaSolidRenderingMaterialDiffuseResponseCmb().removeAllItems();
       getTinaSolidRenderingMaterialDiffuseResponseCmb().addItem(LightDiffFuncPreset.COSA);


### PR DESCRIPTION
Uses the gradient indexed by the distance the transform moved the point.
Color determines the starting point and Speed controls how far along the
gradient each unit of distance moves from there. Like other coloring
types, Speed -1 sets the color to the specified color. The input color
is ignored, so unlike the others Speed 1 will still change the color.

DISTANCE is especially effective for coloring flames made with a single
non-blur transform (blur transforms ignore the input point, so the
distance and thus the color of each point is random).