### PR TITLE
Verify OptiX is available before attempting to use it

### DIFF
--- a/src/org/jwildfire/create/tina/render/optix/OptixCmdLineDenoiser.java
+++ b/src/org/jwildfire/create/tina/render/optix/OptixCmdLineDenoiser.java
@@ -40,39 +40,44 @@ public class OptixCmdLineDenoiser {
   private final String DENOISER_PATH = "Denoiser_v2.4";
 
   public SimpleImage denoise(SimpleImage img, double blend) {
-    try {
-      File tmpFile = File.createTempFile("jwf", ".png");
+    if (isAvailable()) {
       try {
-        String inputFilename = tmpFile.getAbsolutePath();
-        new ImageWriter().saveImage(img, inputFilename);
-        String outputFilename = denoise(inputFilename, blend);
+        File tmpFile = File.createTempFile("jwf", ".png");
         try {
-          SimpleImage denoisedImage = new ImageReader(new JPanel()).loadImage(outputFilename);
-          if(denoisedImage.getImageWidth()>img.getImageWidth() || denoisedImage.getImageHeight() > denoisedImage.getImageHeight()) {
-            CropTransformer crop=new CropTransformer();
-            crop.setLeft(0);
-            crop.setWidth(img.getImageWidth());
-            crop.setTop(0);
-            crop.setHeight(img.getImageHeight());
-            crop.transformImage(denoisedImage);
+          String inputFilename = tmpFile.getAbsolutePath();
+          new ImageWriter().saveImage(img, inputFilename);
+          String outputFilename = denoise(inputFilename, blend);
+          try {
+            SimpleImage denoisedImage = new ImageReader(new JPanel()).loadImage(outputFilename);
+            if(denoisedImage.getImageWidth()>img.getImageWidth() || denoisedImage.getImageHeight() > denoisedImage.getImageHeight()) {
+              CropTransformer crop=new CropTransformer();
+              crop.setLeft(0);
+              crop.setWidth(img.getImageWidth());
+              crop.setTop(0);
+              crop.setHeight(img.getImageHeight());
+              crop.transformImage(denoisedImage);
+            }
+            return denoisedImage;
+          } finally {
+            try {
+              new File(outputFilename).delete();
+            } catch (Exception ex) {
+              new File(outputFilename).deleteOnExit();
+            }
           }
-          return denoisedImage;
         } finally {
           try {
-            new File(outputFilename).delete();
+            tmpFile.delete();
           } catch (Exception ex) {
-            new File(outputFilename).deleteOnExit();
+            tmpFile.deleteOnExit();
           }
         }
-      } finally {
-        try {
-          tmpFile.delete();
-        } catch (Exception ex) {
-          tmpFile.deleteOnExit();
-        }
+      } catch (Exception ex) {
+        throw new RuntimeException(ex);
       }
-    } catch (Exception ex) {
-      throw new RuntimeException(ex);
+    } else {
+      // OptiX not available
+      return img;
     }
   }
 

--- a/src/org/jwildfire/swing/CHANGES.txt
+++ b/src/org/jwildfire/swing/CHANGES.txt
@@ -1,4 +1,4 @@
-V5.60 (06.05.2019)
+V5.60 (06.05.2020)
  - new commandline-tool to create and render random flames.
    Example: java -cp j-wildfire-5.60/lib/j-wildfire.jar org.jwildfire.cli.CreateRandomFlame -w 1200 -h 675 -q 80
  - new variations:
@@ -20,8 +20,8 @@ V5.60 (06.05.2019)
      -crop_triangle, post_crop_triangle,
      -crop_vesica,post_crop_vesica,
      -crop_x,post_crop_x,
-     -pre_zsymmetry,
-     -post_zsymetry,
+     -pre_c_symmetry,
+     -post_c_symetry,
      -pre_c_var,
      -post_c_var, all created by Jesus Sosa
  - new jitter-option for weighting-fields: Adds noise after transforms, so it works well with blurs as well as normal transforms, by Rick Sidwell


### PR DESCRIPTION
Although the OptiX denoiser controls are disabled when OptiX is not
available, it is still possible for it to be enabled. For example, by
loading a flame saved on a computer where it is available (such as flame
shared by someone else). Rendering a flame with OptiX enabled but not
available would display a cryptic message that the denoised file isn't
found and not save the rendered image. This fixes that: no message is
displayed and the image is saved (though not denoised).