### PR TITLE
Add color support for lsystem3D_js

### DIFF
--- a/src/org/jwildfire/create/tina/variation/mesh/AbstractOBJMeshWFFunc.java
+++ b/src/org/jwildfire/create/tina/variation/mesh/AbstractOBJMeshWFFunc.java
@@ -146,6 +146,18 @@ public abstract class AbstractOBJMeshWFFunc extends VariationFunc {
       pVarTP.x += pAmount * dx;
       pVarTP.y += pAmount * dy;
       pVarTP.z += pAmount * dz;
+      
+      if (f instanceof FaceWithColor) {
+        if (((FaceWithColor) f).rgbColor) {
+          pVarTP.rgbColor = true;
+          pVarTP.redColor = ((FaceWithColor) f).redColor;
+          pVarTP.greenColor = ((FaceWithColor) f).greenColor;
+          pVarTP.blueColor = ((FaceWithColor) f).blueColor;
+        } else {
+          pVarTP.color = ((FaceWithColor) f).redColor;
+        }
+      }
+
     }
     if (receive_only_shadows == 1) {
       pVarTP.receiveOnlyShadows = true;

--- a/src/org/jwildfire/create/tina/variation/mesh/FaceWithColor.java
+++ b/src/org/jwildfire/create/tina/variation/mesh/FaceWithColor.java
@@ -1,0 +1,24 @@
+/*
+  JWildfire - an image and animation processor written in Java 
+  Copyright (C) 1995-2016 Andreas Maschke
+
+  This is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser 
+  General Public License as published by the Free Software Foundation; either version 2.1 of the 
+  License, or (at your option) any later version.
+ 
+  This software is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without 
+  even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU 
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License along with this software; 
+  if not, write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  02110-1301 USA, or see the FSF site: http://www.fsf.org.
+*/
+package org.jwildfire.create.tina.variation.mesh;
+
+public class FaceWithColor extends Face {
+  public boolean rgbColor;  // if false, redColor contains the gradient index
+  public double redColor;
+  public double greenColor;
+  public double blueColor;
+}

--- a/src/org/jwildfire/create/tina/variation/mesh/LSystem3DWFFunc.java
+++ b/src/org/jwildfire/create/tina/variation/mesh/LSystem3DWFFunc.java
@@ -60,6 +60,7 @@ public class LSystem3DWFFunc extends AbstractOBJMeshWFFunc {
   protected static final String PARAM_OFFSETX = "offset_x";
   protected static final String PARAM_OFFSETY = "offset_y";
   protected static final String PARAM_OFFSETZ = "offset_z";
+  protected static final String PARAM_COLOR_MODE = "color_mode";
 
   protected static final String PARAM_SUBDIV_LEVEL = "subdiv_level";
   protected static final String PARAM_SUBDIV_SMOOTH_PASSES = "subdiv_smooth_passes";
@@ -72,17 +73,18 @@ public class LSystem3DWFFunc extends AbstractOBJMeshWFFunc {
 
   protected static final String PARAM_RECEIVE_ONLY_SHADOWS = "receive_only_shadows";
 
-  private static final String[] paramNames = {PARAM_PRESETID, PARAM_SCALEX, PARAM_SCALEY, PARAM_SCALEZ, PARAM_OFFSETX, PARAM_OFFSETY, PARAM_OFFSETZ, PARAM_SUBDIV_LEVEL, PARAM_SUBDIV_SMOOTH_PASSES, PARAM_SUBDIV_SMOOTH_LAMBDA, PARAM_SUBDIV_SMOOTH_MU, PARAM_BLEND_COLORMAP, PARAM_DISPL_AMOUNT, PARAM_BLEND_DISPLMAP, PARAM_RECEIVE_ONLY_SHADOWS};
+  private static final String[] paramNames = {PARAM_PRESETID, PARAM_SCALEX, PARAM_SCALEY, PARAM_SCALEZ, PARAM_OFFSETX, PARAM_OFFSETY, PARAM_OFFSETZ, PARAM_COLOR_MODE, PARAM_SUBDIV_LEVEL, PARAM_SUBDIV_SMOOTH_PASSES, PARAM_SUBDIV_SMOOTH_LAMBDA, PARAM_SUBDIV_SMOOTH_MU, PARAM_BLEND_COLORMAP, PARAM_DISPL_AMOUNT, PARAM_BLEND_DISPLMAP, PARAM_RECEIVE_ONLY_SHADOWS};
 
   private String grammar = null;
 
   int presetId = (int) (Math.random() * 21.0 + 1.0);
+  int color_mode = 0;
 
   private static final String[] ressourceNames = {RESSOURCE_GRAMMAR};
 
   @Override
   public Object[] getParameterValues() {
-    return new Object[]{presetId, scaleX, scaleY, scaleZ, offsetX, offsetY, offsetZ, subdiv_level, subdiv_smooth_passes, subdiv_smooth_lambda, subdiv_smooth_mu, colorMapHolder.getBlend_colormap(), displacementMapHolder.getDispl_amount(), displacementMapHolder.getBlend_displ_map(), receive_only_shadows};
+    return new Object[]{presetId, scaleX, scaleY, scaleZ, offsetX, offsetY, offsetZ, color_mode, subdiv_level, subdiv_smooth_passes, subdiv_smooth_lambda, subdiv_smooth_mu, colorMapHolder.getBlend_colormap(), displacementMapHolder.getDispl_amount(), displacementMapHolder.getBlend_displ_map(), receive_only_shadows};
   }
 
   @Override
@@ -116,6 +118,8 @@ public class LSystem3DWFFunc extends AbstractOBJMeshWFFunc {
       offsetY = pValue;
     else if (PARAM_OFFSETZ.equalsIgnoreCase(pName))
       offsetZ = pValue;
+    else if (PARAM_COLOR_MODE.equalsIgnoreCase(pName))
+      color_mode = limitIntVal(Tools.FTOI(pValue), 0, 2);
     else if (PARAM_SUBDIV_LEVEL.equalsIgnoreCase(pName))
       subdiv_level = limitIntVal(Tools.FTOI(pValue), 0, 6);
     else if (PARAM_SUBDIV_SMOOTH_PASSES.equalsIgnoreCase(pName))
@@ -152,6 +156,7 @@ public class LSystem3DWFFunc extends AbstractOBJMeshWFFunc {
       grammar = pValue != null ? new String(pValue) : "";
 
       lsystem3D ls = new lsystem3D();
+      ls.color_mode = color_mode;
       if (ls.readGrammar(grammar) == 0) {
         ls.expand();
         ls.L_draw();
@@ -418,6 +423,7 @@ public class LSystem3DWFFunc extends AbstractOBJMeshWFFunc {
     public int col = 2;
     public int lev = 1;
     public int last_col = 0;
+    public int color_mode = 0;
     public int muts = 0;
     public double ang = (double) 45.0;
     public double thick = (double) 100.0;
@@ -742,7 +748,7 @@ public class LSystem3DWFFunc extends AbstractOBJMeshWFFunc {
         }
         closed_form = false;
       }
-        System.out.println("Axiom              : " + object_s);
+      //  System.out.println("Axiom              : " + object_s);
       // Add default rules
 
       rule.add("+=+");
@@ -1510,14 +1516,31 @@ public class LSystem3DWFFunc extends AbstractOBJMeshWFFunc {
           int v1 = nvert[poly_store[t][0] - 1];
           int v2 = nvert[poly_store[t][1] - 1];
           int v3 = nvert[poly_store[t][2] - 1];
-          mesh.addFace(v1, v2, v3);
+          if (color_mode == 0)
+            mesh.addFace(v1, v2, v3);
+          else if (color_mode == 1) 
+            mesh.addColoredFace(v1,  v2,  v3, (double) color / (double) max_colors);
+          else {
+            if (color >= max_colors) color = max_colors - 1;
+            mesh.addColoredFace(v1,  v2,  v3, color_store[color][_x], color_store[color][_y], color_store[color][_z]);
+          }
           //                   faces.add(new face(vert_count+ poly_store[t][0],vert_count+ poly_store[t][1],vert_count+ poly_store[t][2]));
         } else {
           int v1 = nvert[poly_store[t][0] - 1];
           int v2 = nvert[poly_store[t][1] - 1];
           int v3 = nvert[poly_store[t][2] - 1];
           int v4 = nvert[poly_store[t][3] - 1];
-          mesh.addFace(v1, v2, v3, v4);
+          if (color_mode == 0)
+            mesh.addFace(v1, v2, v3, v4);
+          else if (color_mode == 1) 
+            mesh.addColoredFace(v1,  v2,  v3, v4, (double) color / (double) max_colors);
+          else {
+            if (color >= max_colors) color = max_colors - 1;
+            double r = Math.floor(color_store[color][_x] * 256.0);
+            double g = Math.floor(color_store[color][_y] * 256.0);
+            double b = Math.floor(color_store[color][_z] * 256.0);
+            mesh.addColoredFace(v1,  v2,  v3, v4, r, g, b);
+          }
           //  					mesh.addFace(vert_count + poly_store[t][0] - 1,vert_count + poly_store[t][1] - 1,vert_count +poly_store[t][2] - 1, vert_count+ poly_store[t][3] - 1);
           //                    faces.add(new face(vert_count + poly_store[t][0] - 1,vert_count + poly_store[t][1] - 1,vert_count +poly_store[t][2] - 1, vert_count+ poly_store[t][3] - 1));
         }

--- a/src/org/jwildfire/create/tina/variation/mesh/SimpleMesh.java
+++ b/src/org/jwildfire/create/tina/variation/mesh/SimpleMesh.java
@@ -148,6 +148,66 @@ public class SimpleMesh {
     f2.v3 = p4;
     faces.add(f2);
   }
+  
+  public void addColoredFace(int p1, int p2, int p3, double c) {
+    FaceWithColor f = new FaceWithColor();
+    f.v1 = p1;
+    f.v2 = p2;
+    f.v3 = p3;
+    f.rgbColor = false;
+    f.redColor = c;
+    faces.add(f);
+  }
+
+  public void addColoredFace(int p1, int p2, int p3, double r, double g, double b) {
+    FaceWithColor f = new FaceWithColor();
+    f.v1 = p1;
+    f.v2 = p2;
+    f.v3 = p3;
+    f.rgbColor = true;
+    f.redColor = r;
+    f.greenColor = g;
+    f.blueColor = b;
+    faces.add(f);
+  }
+
+  public void addColoredFace(int p1, int p2, int p3, int p4, double c) {
+    FaceWithColor f1 = new FaceWithColor();
+    f1.v1 = p1;
+    f1.v2 = p2;
+    f1.v3 = p3;
+    faces.add(f1);
+    f1.rgbColor = false;
+    f1.redColor = c;
+    FaceWithColor f2 = new FaceWithColor();
+    f2.v1 = p1;
+    f2.v2 = p3;
+    f2.v3 = p4;
+    f2.rgbColor = false;
+    f2.redColor = c;
+    faces.add(f2);
+  }
+
+  public void addColoredFace(int p1, int p2, int p3, int p4, double r, double g, double b) {
+    FaceWithColor f1 = new FaceWithColor();
+    f1.v1 = p1;
+    f1.v2 = p2;
+    f1.v3 = p3;
+    faces.add(f1);
+    f1.rgbColor = true;
+    f1.redColor = r;
+    f1.greenColor = g;
+    f1.blueColor = b;
+    FaceWithColor f2 = new FaceWithColor();
+    f2.v1 = p1;
+    f2.v2 = p3;
+    f2.v3 = p4;
+    f2.rgbColor = true;
+    f2.redColor = r;
+    f2.greenColor = g;
+    f2.blueColor = b;
+    faces.add(f2);
+  }
 
   public int getFaceCount() {
     return faces.size();


### PR DESCRIPTION
New parameter color_mode:

0 for normal color (default for compatibility); c drawing commands are
ignored.

1 for direct color; c drawing commands set the gradient index for
coloring; color directives are ignored.

2 for rgb color; c drawing commands use the colors set by the color
directives.