### PR TITLE
Fixes/enhancements to some dc_ variations

### DIFF
--- a/src/org/jwildfire/create/tina/variation/DC_FractColorFunc.java
+++ b/src/org/jwildfire/create/tina/variation/DC_FractColorFunc.java
@@ -111,8 +111,7 @@ public class DC_FractColorFunc  extends DC_BaseFunc {
 		       
 		}
 	    else if (pName.equalsIgnoreCase(PARAM_TIME)) {
-		       LocalTime now = LocalTime.now(ZoneId.systemDefault());
-		       time=(double)now.toSecondOfDay();
+            time = pValue;
 		}
 		else if (pName.equalsIgnoreCase(PARAM_XPAR)) {
 			x_par =Tools.limitValue(pValue, 0. , 1.);

--- a/src/org/jwildfire/create/tina/variation/DC_KaleidoscopicFunc.java
+++ b/src/org/jwildfire/create/tina/variation/DC_KaleidoscopicFunc.java
@@ -45,7 +45,7 @@ public class DC_KaleidoscopicFunc  extends DC_BaseFunc {
     int  sides=8;
     double zoom=1.0;
     double p1=0.0;
-    int radial=0;
+    int radial=1;
 
 
 	Random randomize=new Random(seed);

--- a/src/org/jwildfire/create/tina/variation/DC_MandalaFunc.java
+++ b/src/org/jwildfire/create/tina/variation/DC_MandalaFunc.java
@@ -42,9 +42,9 @@ public class DC_MandalaFunc  extends DC_BaseFunc {
 	double mX=0.025;
     double mY=-0.001245675;
     double scale=2.;
-    double sides=12.;
-    double multiply=1.5;
-    double loops=64.;
+    int sides=12;
+    int multiply=1;
+    int loops=64;
     
     int iR=0;
     int iG=0;
@@ -81,16 +81,16 @@ public class DC_MandalaFunc  extends DC_BaseFunc {
      	uv.x = (5.5-scale)*(xp);
      	uv.y = (5.5-scale)*( yp );
      		      	
-    	double k = Math.PI / Math.floor(sides);
+    	double k = Math.PI / (double) sides;
       	vec2 s = G.Kscope(uv,k);
       	vec2 t = G.Kscope(s,k);
       	double v = G.dot(t,s);
     	vec2 u = G.mix(s,t,Math.cos(v));
     	
-    	if (multiply>0.001)
+    	if (multiply>0)
     	{
           vec2 t1=new vec2(u.y,u.x);
-          vec2 t2=G.mod(t1,Math.floor(multiply));
+          vec2 t2=G.mod(t1,(double) multiply);
           vec2 t3=new vec2(-u.x,-u.y);
           vec2 t4=new vec2(u.y,u.x);
           vec2 t5=t4.plus(G.mod(t2,t3));
@@ -98,7 +98,7 @@ public class DC_MandalaFunc  extends DC_BaseFunc {
     	}
       	vec3 p = new vec3 (u, mX*v);
       	for (int l = 0; l < 73; l++) {
-      		if ((double)l > Math.floor(loops))
+      		if ((double)l > loops)
       		{ 
       		  break;
       	    }
@@ -215,13 +215,13 @@ public class DC_MandalaFunc  extends DC_BaseFunc {
 			scale= pValue;
 		} 
 		else if (pName.equalsIgnoreCase(PARAM_SIDES)) {
-			sides= pValue;
+			sides= (int) pValue;
 		} 
 		else if (pName.equalsIgnoreCase(PARAM_MULTIPLY)) {
-			multiply= pValue;
+			multiply= (int) pValue;
 		} 
 		else if (pName.equalsIgnoreCase(PARAM_LOOPS)) {
-			loops= pValue;
+			loops= (int) pValue;
 		} 
 		else if (pName.equalsIgnoreCase(PARAM_IR)) {
 			iR= (int)Tools.limitValue(pValue, 0 , 1);

--- a/src/org/jwildfire/create/tina/variation/DC_QuadtreeFunc.java
+++ b/src/org/jwildfire/create/tina/variation/DC_QuadtreeFunc.java
@@ -45,7 +45,7 @@ public class DC_QuadtreeFunc  extends DC_BaseFunc {
 
 
 
-	double zoom=.50;
+	double zoom=1.;
 	private int seed = 10000;
 	double time=0.0;
 	double width=1000.0;

--- a/src/org/jwildfire/create/tina/variation/DC_RandomOctreeFunc.java
+++ b/src/org/jwildfire/create/tina/variation/DC_RandomOctreeFunc.java
@@ -3,6 +3,7 @@ package org.jwildfire.create.tina.variation;
 import java.util.Random;
 
 import org.jwildfire.base.Tools;
+import static org.jwildfire.base.mathlib.MathLib.fmod;
 import org.jwildfire.create.tina.base.Layer;
 import org.jwildfire.create.tina.base.XForm;
 import org.jwildfire.create.tina.base.XYZPoint;
@@ -47,6 +48,8 @@ public class DC_RandomOctreeFunc  extends DC_BaseFunc {
 	int steps=10;
 	double mouseX=0.0;  // 0-1
 	double mouseY=0.0;  // 0-1
+	double rlr = 0.0;
+	double rud = 0.0;
 	int grid=0;
 	int borders=1;
 	int blackborders=1;
@@ -359,7 +362,7 @@ public class DC_RandomOctreeFunc  extends DC_BaseFunc {
 	}
 
 	public Object[] getParameterValues() { //re_min,re_max,im_min,im_max,
-		return joinArrays(new Object[] { seed, time,steps,mouseX,mouseY,grid,borders,blackborders},super.getParameterValues());
+		return joinArrays(new Object[] { seed, time,steps,rlr,rud,grid,borders,blackborders},super.getParameterValues());
 	}
 
 	public void setParameter(String pName, double pValue) {
@@ -378,10 +381,12 @@ public class DC_RandomOctreeFunc  extends DC_BaseFunc {
 			steps =(int)Tools.limitValue(pValue, 3 , 100);
 		}
 		else if (pName.equalsIgnoreCase(PARAM_RLR)) {
-			mouseX =Tools.limitValue(pValue, 0.0 , 1.0);
+		    rlr = pValue;
+			mouseX = fmod(rlr, 1.0);
 		}
 		else if (pName.equalsIgnoreCase(PARAM_RUD)) {
-			mouseY=Tools.limitValue(pValue, 0.0 , 1.0);
+            rud = pValue;
+            mouseY = fmod(rud, 1.0);
 		}
 		else if (pName.equalsIgnoreCase(PARAM_DRAWGRID)) {
 			grid=(int) Tools.limitValue(pValue, 0 , 1);

--- a/src/org/jwildfire/create/tina/variation/DC_StarsFieldFunc.java
+++ b/src/org/jwildfire/create/tina/variation/DC_StarsFieldFunc.java
@@ -42,7 +42,7 @@ public class DC_StarsFieldFunc  extends DC_BaseFunc {
 
 	double time=0.0;
     double zdistance=2.0;
-    double glow=2.0;
+    double glow=1.0;
 
 	  
 		Random randomize=new Random(seed);

--- a/src/org/jwildfire/create/tina/variation/DC_SunFlowerFunc.java
+++ b/src/org/jwildfire/create/tina/variation/DC_SunFlowerFunc.java
@@ -37,8 +37,6 @@ public class DC_SunFlowerFunc  extends DC_BaseFunc {
 
 
 	private static final String PARAM_ZOOM = "zoom";
-	private static final String PARAM_SEED = "seed";
-	private static final String PARAM_TIME = "time";
 	private static final String PARAM_STEP = "step";
 	private static final String PARAM_N = "N";
 	private static final String PARAM_POLAR = "Polar";
@@ -49,8 +47,6 @@ public class DC_SunFlowerFunc  extends DC_BaseFunc {
 
 
 	double zoom=7.0;
-	private int seed = 10000;
-	double time=0.0;
 	double Step=0.1;
 	int N=30;
 	int  Polar=1;
@@ -58,14 +54,7 @@ public class DC_SunFlowerFunc  extends DC_BaseFunc {
 	int  GridX=1;
 	int  GridY=1;
 
-
-	Random randomize=new Random(seed);
-	
- 	long last_time=System.currentTimeMillis();
- 	long elapsed_time=0;
-	
-
-	private static final String[] additionalParamNames = { PARAM_ZOOM,PARAM_SEED,PARAM_TIME,PARAM_STEP,PARAM_N,PARAM_POLAR,PARAM_DOTS,PARAM_GRIDX,PARAM_GRIDY};
+	private static final String[] additionalParamNames = { PARAM_ZOOM,PARAM_STEP,PARAM_N,PARAM_POLAR,PARAM_DOTS,PARAM_GRIDX,PARAM_GRIDY};
 
 
 	
@@ -99,8 +88,6 @@ public class DC_SunFlowerFunc  extends DC_BaseFunc {
 	    
 	    vec3 O=new vec3(0.);// n  
 
-	    if (r==0.) r = .61803398875  ;
-	    
 	    l = G.length(U);
 	    J.x = l*6.28;                    // jacobian for dots
 	    U = new vec2( G.atan2(U.y,U.x)/6.28 , l ).multiply(N);          // polar coords
@@ -109,14 +96,14 @@ public class DC_SunFlowerFunc  extends DC_BaseFunc {
 	    w=.1;
 	    U.x += r* G.floor(U.y+.5);                        // dot offsetting 
 	    if(GridX==1)
-	       O.x  = S( L(U,1.-r,1), w );
+	      O.x  = S( L(U,((r<0)?-1.:1.)-r,1), w );
 	    if(GridY==1)
 	       O.y  = S( L(U,  -r,1), w );
 	   
 	    if(GridX==0 && GridY==0)
 	    {
-	      O.z  = S( L(U,.5-r,1), w );
-	      U.x+=.5; O.z  += S( L(U,.5-r,1), w ); U.x-=.5;
+	      O.z  = S( L(U,((r<0)?-.5:.5)-r,1), w );
+	      U.x+=.5; O.z  += S( L(U,((r<0)?-.5:.5)-r,1), w ); U.x-=.5;
 	    }
 	    if(Polar==1)
 	         O = O.plus(.5* S( L(U,1,0),    w ));
@@ -141,26 +128,15 @@ public class DC_SunFlowerFunc  extends DC_BaseFunc {
 
 
 	public Object[] getParameterValues() { //re_min,re_max,im_min,im_max,
-		return joinArrays(new Object[] { zoom,seed,time,Step,N,Polar,Dots,GridX,GridY},super.getParameterValues());
+		return joinArrays(new Object[] { zoom,Step,N,Polar,Dots,GridX,GridY},super.getParameterValues());
 	}
 
 	public void setParameter(String pName, double pValue) {
 		if (pName.equalsIgnoreCase(PARAM_ZOOM)) {
 			zoom = Tools.limitValue(pValue, 0.1 , 50.0);
 		}
-		else if (pName.equalsIgnoreCase(PARAM_SEED)) {
-			   seed =   (int)Tools.limitValue(pValue, 0 , 10000);
-		       randomize=new Random(seed);
-		          long current_time = System.currentTimeMillis();
-		          elapsed_time += (current_time - last_time);
-		          last_time = current_time;
-		          time = (double) (elapsed_time / 1000.0);
-		}
-		else if (pName.equalsIgnoreCase(PARAM_TIME)) {
-			time = pValue;
-		}
 		else if (pName.equalsIgnoreCase(PARAM_STEP)) {
-			Step =Tools.limitValue(pValue, 0.00 , 1.0);
+			Step =Tools.limitValue(pValue, -1.00 , 1.0);
 		}
 		else if (pName.equalsIgnoreCase(PARAM_N)) {
 			N = (int)pValue;

--- a/src/org/jwildfire/create/tina/variation/DC_TeslaFunc.java
+++ b/src/org/jwildfire/create/tina/variation/DC_TeslaFunc.java
@@ -31,9 +31,7 @@ public class DC_TeslaFunc  extends DC_BaseFunc {
 
 
 	private static final String PARAM_LEVELS = "levels";
-	private static final String PARAM_THICKNESS = "thicknes";
 	private static final String PARAM_STYLE = "style";
-	private static final String PARAM_SHIFT = "shift";
 	private static final String PARAM_SEED = "seed";
 	private static final String PARAM_TIME = "time";
 	private static final String PARAM_ZOOM = "zoom";
@@ -41,9 +39,7 @@ public class DC_TeslaFunc  extends DC_BaseFunc {
 
 
 	int levels=20;
-	double thickness=1000.;
 	double style=10.0;
-	double shift=1.5;
 	private int seed = 10000;
 	double time=0.0;
 	double zoom=4.0;
@@ -53,7 +49,7 @@ public class DC_TeslaFunc  extends DC_BaseFunc {
  	long last_time=System.currentTimeMillis();
  	long elapsed_time=0;
 	
-	private static final String[] additionalParamNames = { PARAM_LEVELS ,PARAM_THICKNESS,PARAM_STYLE,PARAM_SHIFT,PARAM_SEED,PARAM_TIME,PARAM_ZOOM};
+	private static final String[] additionalParamNames = { PARAM_LEVELS,PARAM_STYLE,PARAM_SEED,PARAM_TIME,PARAM_ZOOM};
 
 
 public	double field21( vec3 p, double s) {
@@ -99,7 +95,7 @@ public	double field21( vec3 p, double s) {
 
 
 	public Object[] getParameterValues() { //re_min,re_max,im_min,im_max,
-		return joinArrays(new Object[] { levels,thickness,style,shift,seed,time,zoom},super.getParameterValues());
+		return joinArrays(new Object[] { levels,style,seed,time,zoom},super.getParameterValues());
 	}
 
 
@@ -109,17 +105,9 @@ public	double field21( vec3 p, double s) {
 			
 			levels = (int)Tools.limitValue(pValue, 1 , 25);
 		}
-		else if (pName.equalsIgnoreCase(PARAM_THICKNESS)) {
-			
-			thickness = (int)Tools.limitValue(pValue, -1500. , 1500.);
-		}
 		else if (pName.equalsIgnoreCase(PARAM_STYLE)) {
 			
 			style = Tools.limitValue(pValue, 5. , 100.);
-		}
-		else if (pName.equalsIgnoreCase(PARAM_SHIFT)) {
-			
-			shift = Tools.limitValue(pValue, -100. , 100.);
 		}
 		else if (PARAM_SEED.equalsIgnoreCase(pName)) 
 		{	   seed =  (int) pValue;

--- a/src/org/jwildfire/create/tina/variation/DC_WorleyFunc.java
+++ b/src/org/jwildfire/create/tina/variation/DC_WorleyFunc.java
@@ -24,7 +24,7 @@ import js.glsl.vec4;
 public class DC_WorleyFunc  extends DC_BaseFunc {
 
 	/*
-	 * Variation : dc_cairotiles
+	 * Variation : dc_worley
 	 * Autor: Jesus Sosa
 	 * Date: February 13, 2019
 	 * Reference 
@@ -37,27 +37,18 @@ public class DC_WorleyFunc  extends DC_BaseFunc {
 
 
 	private static final String PARAM_ZOOM = "zoom";
-	private static final String PARAM_SEED = "seed";
-	private static final String PARAM_TIME = "time";
-
-
+	private static final String PARAM_PATTERN = "pattern";
+    private static final String PARAM_DISTORT = "distort";
 
 	double zoom=7.0;
-	private int seed = 10000;
-	double time=0.0;
-
-
-	Random randomize=new Random(seed);
+	double pattern = 70.0;
+	double distort = 1.0;
 	
- 	long last_time=System.currentTimeMillis();
- 	long elapsed_time=0;
-	
-
-	private static final String[] additionalParamNames = { PARAM_ZOOM,PARAM_SEED,PARAM_TIME};
+	private static final String[] additionalParamNames = { PARAM_ZOOM, PARAM_PATTERN, PARAM_DISTORT};
 
 	vec2 H(vec2 n)
 	{
-	    return G.fract( new vec2(1,12.34).plus(1e4 * sin( n.x+n.y/.7)  ) ).multiply(.7).plus(.3);
+	    return G.fract( new vec2(1,12.34).plus(1e4 * sin( n.x+n.y/(pattern*.01))  ) ).multiply(distort*0.75).plus(.3);
 	}
 
 	public vec3 getRGBColor(double xp,double yp)
@@ -120,25 +111,19 @@ public class DC_WorleyFunc  extends DC_BaseFunc {
 
 
 	public Object[] getParameterValues() { //re_min,re_max,im_min,im_max,
-		return joinArrays(new Object[] { zoom,seed,time},super.getParameterValues());
+		return joinArrays(new Object[] { zoom, pattern, distort },super.getParameterValues());
 	}
 
 	public void setParameter(String pName, double pValue) {
 		if (pName.equalsIgnoreCase(PARAM_ZOOM)) {
 			zoom = Tools.limitValue(pValue, 0.1 , 50.0);
 		}
-		else if (pName.equalsIgnoreCase(PARAM_SEED)) {
-			   seed =   (int)Tools.limitValue(pValue, 0 , 10000);
-		       randomize=new Random(seed);
-		          long current_time = System.currentTimeMillis();
-		          elapsed_time += (current_time - last_time);
-		          last_time = current_time;
-		          time = (double) (elapsed_time / 1000.0);
+		else if (pName.equalsIgnoreCase(PARAM_PATTERN)) {
+		  pattern = Tools.limitValue(pValue, 0.1 , 100.0);
 		}
-		else if (pName.equalsIgnoreCase(PARAM_TIME)) {
-			time = pValue;
+		else if (pName.equalsIgnoreCase(PARAM_DISTORT)) {
+		  distort = Tools.limitValue(pValue, 0.0 , 1.0);
 		}
-
 		else
 			super.setParameter(pName, pValue);
 	}


### PR DESCRIPTION
dc_fractcolor: changing time parameter did not work
dc_kaleidoscopic: changed default for Radial to 1 since that is more
"kaleidoscopic"
dc_mandala: changed sides, multiply, and loops to integers so spinner
buttons work better
dc_quadtree: changed default for zoom to 1 to better fit the space
dc_randomoctree: removed restriction of Rot parameters (was 0-1); no new
functionality, but it allows easier animation
dc_starsfield: changed default for glow to 1 (was 2, which is higher
than the max)
dc_sunflower: removed unused seed and time parameters, and allow
negative values for step to reverse the spiral direction
dc_tesla: removed unused thicknes and shift parameters
dc_worley: removed unused seed and time parameters, and add new pattern
and distort parameters to allow changing the pattern