### PR TITLE
Allow files without gradients in gradient directory

### DIFF
--- a/src/org/jwildfire/create/tina/GradientController.java
+++ b/src/org/jwildfire/create/tina/GradientController.java
@@ -306,9 +306,9 @@ public class GradientController {
   private void readGradients(GradientUserNode pNode, List<String> pFilenames) {
     for (String filename : pFilenames) {
       List<RGBPalette> gradients = new UniversalPaletteReader().readPalettes(filename);
-      gradients.sort(
-          (p1, p2) -> (p1.getFlam3Name()!=null ? p1.getFlam3Name(): "").compareToIgnoreCase(p2.getFlam3Name()));
       if (gradients != null && gradients.size() > 0) {
+        gradients.sort(
+            (p1, p2) -> (p1.getFlam3Name()!=null ? p1.getFlam3Name(): "").compareToIgnoreCase(p2.getFlam3Name()));
         pNode.getGradientLibraryList().addAll(gradients);
       }
     }


### PR DESCRIPTION
Bug fix: Check to make sure gradients exist in a file before trying to sort them.