### PR TITLE
Create RomanescoFunc.java

### DIFF
--- a/src/org/jwildfire/create/tina/variation/RomanescoFunc.java
+++ b/src/org/jwildfire/create/tina/variation/RomanescoFunc.java
@@ -42,6 +42,11 @@ public class RomanescoFunc extends VariationFunc {
     private static final String PARAM_CONE_STEEPNESS = "cone_steepness";
     private static final String PARAM_FLORET_DETAIL_SIZE = "floret_detail_size";
     private static final String PARAM_FLORET_SHAPE = "floret_shape";
+    
+    // New Rotation Parameters
+    private static final String PARAM_PITCH = "pitch";
+    private static final String PARAM_YAW = "yaw";
+    private static final String PARAM_ROLL = "roll";
 
     // Coloring Parameters
     private static final String PARAM_COLOR_MODE = "color_mode";
@@ -61,6 +66,7 @@ public class RomanescoFunc extends VariationFunc {
             PARAM_CONE_STEEPNESS,
             PARAM_FLORET_DETAIL_SIZE,
             PARAM_FLORET_SHAPE,
+            PARAM_PITCH, PARAM_YAW, PARAM_ROLL, // New
             PARAM_COLOR_MODE,
             PARAM_SOLID_COLOR_IDX,
             PARAM_COLOR_RANGE_MIN,
@@ -68,7 +74,7 @@ public class RomanescoFunc extends VariationFunc {
     };
 
     private double size = 0.5;
-    private int recursion_depth = 5;
+    private int recursion_depth = 7;
     private int num_arms = 1;
     private double arm_spread = 1.0;
     private double arm_elevation = 45.0;
@@ -80,6 +86,9 @@ public class RomanescoFunc extends VariationFunc {
     private double cone_steepness = 1.0;
     private double floret_detail_size = 0.1;
     private int floret_shape = 0;
+    private double pitch = 180.0; // New
+    private double yaw = 0.0;   // New
+    private double roll = 0.0;  // New
     private int color_mode = 0;
     private double solid_color_idx = 0.5;
     private double color_range_min = 0.0;
@@ -117,7 +126,7 @@ public class RomanescoFunc extends VariationFunc {
 
             axis_z.x = cos(arm_angle) * cos(elevation_rad);
             axis_z.y = sin(arm_angle) * cos(elevation_rad);
-            axis_z.z = -sin(elevation_rad); // THIS IS THE FIRST CHANGE (Negative sign)
+            axis_z.z = sin(elevation_rad);
             
             XYZPoint up_vec = new XYZPoint(); up_vec.z=1;
             if (Math.abs(axis_z.z) > 0.999) { up_vec.x=1; up_vec.z=0;}
@@ -135,7 +144,7 @@ public class RomanescoFunc extends VariationFunc {
 
             double local_x = r * cos(spiral_angle);
             double local_y = r * sin(spiral_angle);
-            double local_z = -r * this.cone_steepness; // THIS IS THE SECOND CHANGE (Negative sign)
+            double local_z = r * this.cone_steepness;
 
             pos.x += (axis_x.x * local_x + axis_y.x * local_y + axis_z.x * local_z) * current_scale;
             pos.y += (axis_x.y * local_x + axis_y.y * local_y + axis_z.y * local_z) * current_scale;
@@ -201,6 +210,34 @@ public class RomanescoFunc extends VariationFunc {
         double final_y = pos.y + (axis_x.y * local_x_final + axis_y.y * local_y_final + axis_z.y * local_z_final);
         double final_z = pos.z + (axis_x.z * local_x_final + axis_y.z * local_y_final + axis_z.z * local_z_final);
         
+        // Apply Rotations to the final calculated point
+        if (pitch != 0.0 || yaw != 0.0 || roll != 0.0) {
+            double cos_p = Math.cos(Math.toRadians(pitch));
+            double sin_p = Math.sin(Math.toRadians(pitch));
+            double cos_y = Math.cos(Math.toRadians(yaw));
+            double sin_y = Math.sin(Math.toRadians(yaw));
+            double cos_r = Math.cos(Math.toRadians(roll));
+            double sin_r = Math.sin(Math.toRadians(roll));
+
+            // Yaw (Y-axis rotation)
+            double tempX = final_x * cos_y - final_z * sin_y;
+            double tempZ = final_x * sin_y + final_z * cos_y;
+            final_x = tempX;
+            final_z = tempZ;
+            
+            // Pitch (X-axis rotation)
+            double tempY = final_y * cos_p - final_z * sin_p;
+            tempZ = final_y * sin_p + final_z * cos_p;
+            final_y = tempY;
+            final_z = tempZ;
+
+            // Roll (Z-axis rotation)
+            tempX = final_x * cos_r - final_y * sin_r;
+            tempY = final_x * sin_r + final_y * cos_r;
+            final_x = tempX;
+            final_y = tempY;
+        }
+        
         // Coloring Logic
         double color_index = 0.5;
         double range = color_range_max - color_range_min;
@@ -235,6 +272,7 @@ public class RomanescoFunc extends VariationFunc {
                 size, recursion_depth,
                 num_arms, arm_spread, arm_elevation, arm_twist,
                 floret_count, floret_scale, pattern_spread, spiral_twist, cone_steepness, floret_detail_size, floret_shape,
+                pitch, yaw, roll, // New
                 color_mode, solid_color_idx, color_range_min, color_range_max
         };
     }
@@ -254,6 +292,9 @@ public class RomanescoFunc extends VariationFunc {
         else if (PARAM_CONE_STEEPNESS.equalsIgnoreCase(pName)) cone_steepness = pValue;
         else if (PARAM_FLORET_DETAIL_SIZE.equalsIgnoreCase(pName)) floret_detail_size = pValue;
         else if (PARAM_FLORET_SHAPE.equalsIgnoreCase(pName)) floret_shape = (int) pValue;
+        else if (PARAM_PITCH.equalsIgnoreCase(pName)) pitch = pValue; // New
+        else if (PARAM_YAW.equalsIgnoreCase(pName)) yaw = pValue;     // New
+        else if (PARAM_ROLL.equalsIgnoreCase(pName)) roll = pValue;   // New
         else if (PARAM_COLOR_MODE.equalsIgnoreCase(pName)) color_mode = (int) pValue;
         else if (PARAM_SOLID_COLOR_IDX.equalsIgnoreCase(pName)) solid_color_idx = pValue;
         else if (PARAM_COLOR_RANGE_MIN.equalsIgnoreCase(pName)) color_range_min = pValue;


### PR DESCRIPTION
User Manual: romanesco Variation
Overview
Welcome to the romanesco variation! This is a powerful 3D fractal generator designed to create complex, self-similar structures inspired by Romanesco broccoli, cauliflower, and other natural forms. You can create everything from single, perfect conical spirals to entire clusters of branching, alien-like coral.

The key to this variation is its recursive engine. It builds shapes by placing smaller copies of itself onto a parent shape, creating incredible levels of detail.

Getting Started: Quick Recipes
The best way to learn is to start with a working example. Try these settings to see what the variation can do.

Recipe 1: The Classic Romanesco
This creates a single, iconic, spiraling cone.

size: 3.0
recursion_depth: 7
num_arms: 1
floret_count: 150
floret_scale: 0.88
pattern_spread: 0.3
cone_steepness: 1.5
spiral_twist: 1.0
floret_detail_size: 0.1
floret_shape: 0 (Sphere)
color_mode: 3 (Height)
color_range_min: -2.0
color_range_max: 4.0
Recipe 2: Abstract Branching Coral
This uses the "Arms" and "Floret Shape" features to create a completely different look.

size: 2.5
recursion_depth: 6
num_arms: 7
arm_spread: 0.6
arm_elevation: 55.0
arm_twist: 0.2
floret_count: 80
floret_scale: 0.9
pattern_spread: 0.2
cone_steepness: 0.7
floret_detail_size: 0.06
floret_shape: 3 (Ring)
color_mode: 1 (Distance from Center)
color_range_min: 0.0
color_range_max: 2.5
Parameter Breakdown
Main Controls
size: The overall size of the entire fractal.
recursion_depth: The most important control for detail. It sets how many levels of self-similar florets are generated. Higher values (8+) create incredible detail but will take much longer to render. Start with 5-7. Branching (The "Arms")
These controls are only active when num_arms is greater than 1.

num_arms: The number of main branches that grow from the center. Set to 1 for a single cone. arm_spread: Controls how far apart the arms are from the center. arm_elevation: Sets the angle of the arms in degrees. 0 makes them spread out flat, while 90 makes them all point straight up. arm_twist: Adds a slight spiral to the placement of the arms themselves for a more dynamic look. Spiral Pattern (The "Florets")
These parameters define the shape and pattern of each individual cone/branch.

floret_count: The number of smaller cones that appear on each larger cone. Higher values make the spirals look more defined. floret_scale: The size of each child floret relative to its parent. This value MUST be less than 1.0 (e.g., 0.85) for the fractal to converge. If it's 1.0 or higher, the fractal will "explode." pattern_spread: Controls the width of the cone. It spreads the florets out horizontally. (This was formerly spiral_spread). spiral_twist: Controls the tightness of the spiral. 1.0 is the natural golden-angle spiral. Lower values make the spiral tighter; higher values make it looser. cone_steepness: Controls the height of the cone. Higher values create a sharper, more pointed cone. Surface Detail
floret_detail_size: Controls the size of the geometric shape used to render the surface of the florets. If this is 0, the fractal will look like sparse dust. floret_shape: A switch to change the basic building block of the fractal. 0: Sphere: The default, bumpy, organic look.
1: Cube: Builds the fractal from tiny cubes.
2: Spike: Creates a texture of sharp, outward-pointing spikes. 3: Ring: Uses tiny rings, creating a delicate and intricate look. Advanced Coloring
color_mode: A switch to select the coloring algorithm. 0: Solid Color: Uses a single color defined by solid_color_idx. 1: Color by Distance from Center: Creates a gradient from the core of the fractal outwards. 2: Color by Radius from Axis: Creates concentric rings of color around the central (vertical) axis. 3: Color by Height: Creates a vertical gradient.
solid_color_idx: Selects the color from the gradient when color_mode is 0. color_range_min / color_range_max: These sliders define the range over which the gradient is mapped for modes 1, 2, and 3. For example, in "Color by Height" mode, setting this range from 0 to 4 will map your entire color gradient across the Z-axis from Z=0 to Z=4.